### PR TITLE
chore: update protos to lnd 18.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "async-stream"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -45,9 +45,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.5"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bitflags"
@@ -151,9 +151,9 @@ checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
@@ -189,7 +189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -214,6 +214,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tower",
+ "tracing",
 ]
 
 [[package]]
@@ -286,9 +287,9 @@ checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
 name = "h2"
-version = "0.3.21"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -296,7 +297,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 1.9.3",
+ "indexmap 2.0.2",
  "slab",
  "tokio",
  "tokio-util",
@@ -322,31 +323,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "home"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
 name = "http"
-version = "0.2.9"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -355,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
  "http",
@@ -366,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -378,9 +364,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.27"
+version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -393,7 +379,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -463,9 +449,9 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "linux-raw-sys"
@@ -508,13 +494,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.9"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -522,16 +508,6 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
 
 [[package]]
 name = "object"
@@ -598,9 +574,12 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -614,18 +593,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prost"
-version = "0.12.1"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fdd22f3b9c31b53c060df4a0613a1c7f062d4115a2b984dd15b1858f7e340d"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -633,9 +612,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.12.1"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bdf592881d821b83d471f8af290226c8d51402259e9bb5be7f9f8bdebbb11ac"
+checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck",
@@ -650,14 +629,13 @@ dependencies = [
  "regex",
  "syn",
  "tempfile",
- "which",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.12.1"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "265baba7fabd416cf5078179f7d2cbeca4ce7a9041111900675ea7c4cb8a4c32"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
  "itertools",
@@ -668,18 +646,18 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.12.1"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e081b29f63d83a4bc75cfc9f3fe424f9156cf92d8a4f0c9407cce9a1b67327cf"
+checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
  "prost",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -763,7 +741,7 @@ dependencies = [
  "libc",
  "spin",
  "untrusted",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -782,14 +760,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.21.8"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446e14c5cda4f3f30fe71863c34ec70f5ac79d6087097ad0bb433e1be5edf04c"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",
@@ -799,9 +777,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64",
 ]
@@ -863,22 +841,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
-dependencies = [
- "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -889,9 +857,9 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -914,24 +882,23 @@ dependencies = [
  "fastrand",
  "redox_syscall",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.33.0"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "pin-project-lite",
- "socket2 0.5.5",
+ "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -946,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -967,9 +934,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.14"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -1055,15 +1022,15 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -1131,46 +1098,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
-]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1179,13 +1121,29 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -1195,10 +1153,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1207,10 +1177,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1219,13 +1207,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,10 @@ invoicesrpc = ["lightningrpc"]
 staterpc = ["lightningrpc"]
 all = ["lightningrpc", "walletrpc", "peersrpc", "versionrpc", "routerrpc", "invoicesrpc", "staterpc"]
 default = ["all"]
+tracing = ["dep:tracing"]
 
 [dependencies]
+tracing = { version = "0.1", optional = true }
 hex = "0.4.3"
 http-body = "0.4.5"
 hyper = { version = "0.14.27", features = ["client"], default-features = false }

--- a/build.rs
+++ b/build.rs
@@ -22,7 +22,7 @@ fn main() -> std::io::Result<()> {
         "verrpc/verrpc.proto",
         "routerrpc/router.proto",
         "invoicesrpc/invoices.proto",
-        "staterpc/state.proto",
+        "stateservice.proto",
     ];
 
     let proto_paths: Vec<_> = protos.iter().map(|proto| dir.join(proto)).collect();
@@ -30,6 +30,7 @@ fn main() -> std::io::Result<()> {
     tonic_build::configure()
         .build_client(true)
         .build_server(false)
+        .protoc_arg("--experimental_allow_proto3_optional")
         .compile(&proto_paths, &[dir])?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,7 @@ pub mod invoicesrpc {
 
 #[cfg(feature = "staterpc")]
 pub mod staterpc {
-    tonic::include_proto!("staterpc");
+    tonic::include_proto!("lnrpc");
 }
 
 /// Supplies requests with macaroon

--- a/vendor/invoicesrpc/invoices.proto
+++ b/vendor/invoicesrpc/invoices.proto
@@ -1,10 +1,28 @@
 syntax = "proto3";
 
-import "lightning.proto";
-
 package invoicesrpc;
 
+import "lightning.proto";
+
 option go_package = "github.com/lightningnetwork/lnd/lnrpc/invoicesrpc";
+
+/*
+ * Comments in this file will be directly parsed into the API
+ * Documentation as descriptions of the associated method, message, or field.
+ * These descriptions should go right above the definition of the object, and
+ * can be in either block or // comment format.
+ *
+ * An RPC method can be matched to an lncli command by placing a line in the
+ * beginning of the description in exactly the following format:
+ * lncli: `methodname`
+ *
+ * Failure to specify the exact name of the command will cause documentation
+ * generation to fail.
+ *
+ * More information on how exactly the gRPC documentation is generated from
+ * this proto file can be found here:
+ * https://github.com/lightninglabs/lightning-api
+ */
 
 // Invoices is a service that can be used to create, accept, settle and cancel
 // invoices.
@@ -17,30 +35,39 @@ service Invoices {
     rpc SubscribeSingleInvoice (SubscribeSingleInvoiceRequest)
         returns (stream lnrpc.Invoice);
 
-    /*
+    /* lncli: `cancelinvoice`
     CancelInvoice cancels a currently open invoice. If the invoice is already
     canceled, this call will succeed. If the invoice is already settled, it will
     fail.
     */
     rpc CancelInvoice (CancelInvoiceMsg) returns (CancelInvoiceResp);
 
-    /*
+    /* lncli: `addholdinvoice`
     AddHoldInvoice creates a hold invoice. It ties the invoice to the hash
     supplied in the request.
     */
     rpc AddHoldInvoice (AddHoldInvoiceRequest) returns (AddHoldInvoiceResp);
 
-    /*
+    /* lncli: `settleinvoice`
     SettleInvoice settles an accepted invoice. If the invoice is already
     settled, this call will succeed.
     */
     rpc SettleInvoice (SettleInvoiceMsg) returns (SettleInvoiceResp);
 
     /*
-    LookupInvoiceV2 attempts to look up at invoice. An invoice can be refrenced
+    LookupInvoiceV2 attempts to look up at invoice. An invoice can be referenced
     using either its payment hash, payment address, or set ID.
     */
     rpc LookupInvoiceV2 (LookupInvoiceMsg) returns (lnrpc.Invoice);
+
+    /*
+    HtlcModifier is a bidirectional streaming RPC that allows a client to
+    intercept and modify the HTLCs that attempt to settle the given invoice. The
+    server will send HTLCs of invoices to the client and the client can modify
+    some aspects of the HTLC in order to pass the invoice acceptance tests.
+    */
+    rpc HtlcModifier (stream HtlcModifyResponse)
+        returns (stream HtlcModifyRequest);
 }
 
 message CancelInvoiceMsg {
@@ -120,8 +147,9 @@ message AddHoldInvoiceResp {
     uint64 add_index = 2;
 
     /*
-    The payment address of the generated invoice. This value should be used
-    in all payments for this invoice as we require it for end to end
+    The payment address of the generated invoice. This is also called
+    the payment secret in specifications (e.g. BOLT 11). This value should
+    be used in all payments for this invoice as we require it for end to end
     security.
     */
     bytes payment_addr = 3;
@@ -172,4 +200,52 @@ message LookupInvoiceMsg {
     }
 
     LookupModifier lookup_modifier = 4;
+}
+
+// CircuitKey is a unique identifier for an HTLC.
+message CircuitKey {
+    // The id of the channel that the is part of this circuit.
+    uint64 chan_id = 1;
+
+    // The index of the incoming htlc in the incoming channel.
+    uint64 htlc_id = 2;
+}
+
+message HtlcModifyRequest {
+    // The invoice the intercepted HTLC is attempting to settle. The HTLCs in
+    // the invoice are only HTLCs that have already been accepted or settled,
+    // not including the current intercepted HTLC.
+    lnrpc.Invoice invoice = 1;
+
+    // The unique identifier of the HTLC of this intercepted HTLC.
+    CircuitKey exit_htlc_circuit_key = 2;
+
+    // The amount in milli-satoshi that the exit HTLC is attempting to pay.
+    uint64 exit_htlc_amt = 3;
+
+    // The absolute expiry height of the exit HTLC.
+    uint32 exit_htlc_expiry = 4;
+
+    // The current block height.
+    uint32 current_height = 5;
+
+    // The wire message custom records of the exit HTLC.
+    map<uint64, bytes> exit_htlc_wire_custom_records = 6;
+}
+
+message HtlcModifyResponse {
+    // The circuit key of the HTLC that the client wants to modify.
+    CircuitKey circuit_key = 1;
+
+    // The modified amount in milli-satoshi that the exit HTLC is paying. This
+    // value can be different from the actual on-chain HTLC amount, in case the
+    // HTLC carries other valuable items, as can be the case with custom channel
+    // types.
+    optional uint64 amt_paid = 2;
+
+    // This flag indicates whether the HTLCs associated with the invoices should
+    // be cancelled. The interceptor client may set this field if some
+    // unexpected behavior is encountered. Setting this will ignore the amt_paid
+    // field.
+    bool cancel_set = 3;
 }

--- a/vendor/lightning.proto
+++ b/vendor/lightning.proto
@@ -101,8 +101,10 @@ service Lightning {
     rpc SignMessage (SignMessageRequest) returns (SignMessageResponse);
 
     /* lncli: `verifymessage`
-    VerifyMessage verifies a signature over a msg. The signature must be
-    zbase32 encoded and signed by an active node in the resident node's
+    VerifyMessage verifies a signature over a message and recovers the signer's
+    public key. The signature is only deemed valid if the recovered public key
+    corresponds to a node key in the public Lightning network. The signature
+    must be zbase32 encoded and signed by an active node in the resident node's
     channel database. In addition to returning the validity of the signature,
     VerifyMessage also returns the recovered pubkey from the signature.
     */
@@ -140,6 +142,13 @@ service Lightning {
     concerning the number of open+pending channels.
     */
     rpc GetInfo (GetInfoRequest) returns (GetInfoResponse);
+
+    /* lncli: 'getdebuginfo'
+    GetDebugInfo returns debug information concerning the state of the daemon
+    and its subsystems. This includes the full configuration and the latest log
+    entries from the log file.
+    */
+    rpc GetDebugInfo (GetDebugInfoRequest) returns (GetDebugInfoResponse);
 
     /** lncli: `getrecoveryinfo`
     GetRecoveryInfo returns information concerning the recovery mode including
@@ -320,7 +329,7 @@ service Lightning {
     optionally specify the add_index and/or the settle_index. If the add_index
     is specified, then we'll first start by sending add invoice events for all
     invoices with an add_index greater than the specified value. If the
-    settle_index is specified, the next, we'll send out all settle events for
+    settle_index is specified, then next, we'll send out all settle events for
     invoices with a settle_index greater than the specified value. One or both
     of these fields can be set. If no fields are set, then we'll only send out
     the latest add/settle events.
@@ -339,13 +348,13 @@ service Lightning {
     */
     rpc ListPayments (ListPaymentsRequest) returns (ListPaymentsResponse);
 
-    /*
+    /* lncli: `deletepayments`
     DeletePayment deletes an outgoing payment from DB. Note that it will not
     attempt to delete an In-Flight payment, since that would be unsafe.
     */
     rpc DeletePayment (DeletePaymentRequest) returns (DeletePaymentResponse);
 
-    /*
+    /* lncli: `deletepayments --all`
     DeleteAllPayments deletes all outgoing payments from DB. Note that it will
     not attempt to delete In-Flight payments, since that would be unsafe.
     */
@@ -477,7 +486,7 @@ service Lightning {
     rpc ExportAllChannelBackups (ChanBackupExportRequest)
         returns (ChanBackupSnapshot);
 
-    /*
+    /* lncli: `verifychanbackup`
     VerifyChanBackup allows a caller to verify the integrity of a channel backup
     snapshot. This method will accept either a packed Single or a packed Multi.
     Specifying both will result in an error.
@@ -567,6 +576,10 @@ service Lightning {
     /* lncli: `subscribecustom`
     SubscribeCustomMessages subscribes to a stream of incoming custom peer
     messages.
+
+    To include messages with type outside of the custom range (>= 32768) lnd
+    needs to be compiled with  the `dev` build tag, and the message type to
+    override should be specified in lnd's experimental protocol configuration.
     */
     rpc SubscribeCustomMessages (SubscribeCustomMessagesRequest)
         returns (stream CustomMessage);
@@ -577,6 +590,28 @@ service Lightning {
     zero conf).
     */
     rpc ListAliases (ListAliasesRequest) returns (ListAliasesResponse);
+
+    /*
+    LookupHtlcResolution retrieves a final htlc resolution from the database.
+    If the htlc has no final resolution yet, a NotFound grpc status code is
+    returned.
+    */
+    rpc LookupHtlcResolution (LookupHtlcResolutionRequest)
+        returns (LookupHtlcResolutionResponse);
+}
+
+message LookupHtlcResolutionRequest {
+    uint64 chan_id = 1;
+
+    uint64 htlc_index = 2;
+}
+
+message LookupHtlcResolutionResponse {
+    // Settled is true is the htlc was settled. If false, the htlc was failed.
+    bool settled = 1;
+
+    // Offchain indicates whether the htlc was resolved off-chain or on-chain.
+    bool offchain = 2;
 }
 
 message SubscribeCustomMessagesRequest {
@@ -598,6 +633,9 @@ message SendCustomMessageRequest {
     bytes peer = 1;
 
     // Message type. This value needs to be in the custom range (>= 32768).
+    // To send a type < custom range, lnd needs to be compiled with the `dev`
+    // build tag, and the message type to override should be specified in lnd's
+    // experimental protocol configuration.
     uint32 type = 2;
 
     // Raw message data.
@@ -637,6 +675,7 @@ enum OutputScriptType {
     SCRIPT_TYPE_NULLDATA = 6;
     SCRIPT_TYPE_NON_STANDARD = 7;
     SCRIPT_TYPE_WITNESS_UNKNOWN = 8;
+    SCRIPT_TYPE_WITNESS_V1_TAPROOT = 9;
 }
 
 message OutputDetail {
@@ -845,7 +884,8 @@ message SendRequest {
     repeated FeatureBit dest_features = 15;
 
     /*
-    The payment address of the generated invoice.
+    The payment address of the generated invoice.  This is also called
+    payment secret in specifications (e.g. BOLT 11).
     */
     bytes payment_addr = 16;
 }
@@ -1051,6 +1091,18 @@ message LightningAddress {
     string host = 2;
 }
 
+enum CoinSelectionStrategy {
+    // Use the coin selection strategy defined in the global configuration
+    // (lnd.conf).
+    STRATEGY_USE_GLOBAL_CONFIG = 0;
+
+    // Select the largest available coins first during coin selection.
+    STRATEGY_LARGEST = 1;
+
+    // Randomly select the available coins during coin selection.
+    STRATEGY_RANDOM = 2;
+}
+
 message EstimateFeeRequest {
     // The map from addresses to amounts for the transaction.
     map<string, int64> AddrToAmount = 1;
@@ -1065,6 +1117,9 @@ message EstimateFeeRequest {
 
     // Whether unconfirmed outputs should be used as inputs for the transaction.
     bool spend_unconfirmed = 4;
+
+    // The strategy to use for selecting coins during fees estimation.
+    CoinSelectionStrategy coin_selection_strategy = 5;
 }
 
 message EstimateFeeResponse {
@@ -1105,6 +1160,9 @@ message SendManyRequest {
 
     // Whether unconfirmed outputs should be used as inputs for the transaction.
     bool spend_unconfirmed = 8;
+
+    // The strategy to use for selecting coins during sending many requests.
+    CoinSelectionStrategy coin_selection_strategy = 9;
 }
 message SendManyResponse {
     // The id of the transaction
@@ -1132,9 +1190,8 @@ message SendCoinsRequest {
     int64 sat_per_byte = 5 [deprecated = true];
 
     /*
-    If set, then the amount field will be ignored, and lnd will attempt to
-    send all the coins under control of the internal wallet to the specified
-    address.
+    If set, the amount field should be unset. It indicates lnd will send all
+    wallet coins or all selected coins to the specified address.
     */
     bool send_all = 6;
 
@@ -1147,6 +1204,12 @@ message SendCoinsRequest {
 
     // Whether unconfirmed outputs should be used as inputs for the transaction.
     bool spend_unconfirmed = 9;
+
+    // The strategy to use for selecting coins.
+    CoinSelectionStrategy coin_selection_strategy = 10;
+
+    // A list of selected outpoints as inputs for the transaction.
+    repeated OutPoint outpoints = 11;
 }
 message SendCoinsResponse {
     // The transaction ID of the transaction
@@ -1320,6 +1383,19 @@ enum CommitmentType {
     channel before its maturity date.
     */
     SCRIPT_ENFORCED_LEASE = 4;
+
+    /*
+    A channel that uses musig2 for the funding output, and the new tapscript
+    features where relevant.
+    */
+    SIMPLE_TAPROOT = 5;
+
+    /*
+    Identical to the SIMPLE_TAPROOT channel type, but with extra functionality.
+    This channel type also commits to additional meta data in the tapscript
+    leaves for the scripts in a channel.
+    */
+    SIMPLE_TAPROOT_OVERLAY = 6;
 }
 
 message ChannelConstraints {
@@ -1509,6 +1585,24 @@ message Channel {
 
     // This is the confirmed / on-chain zero-conf SCID.
     uint64 zero_conf_confirmed_scid = 33;
+
+    // The configured alias name of our peer.
+    string peer_alias = 34;
+
+    // This is the peer SCID alias.
+    uint64 peer_scid_alias = 35 [jstype = JS_STRING];
+
+    /*
+    An optional note-to-self to go along with the channel containing some
+    useful information. This is only ever stored locally and in no way impacts
+    the channel's operation.
+    */
+    string memo = 36;
+
+    /*
+    Custom channel data that might be populated in custom channels.
+    */
+    bytes custom_channel_data = 37;
 }
 
 message ListChannelsRequest {
@@ -1522,6 +1616,11 @@ message ListChannelsRequest {
     empty, all channels will be returned.
     */
     bytes peer = 5;
+
+    // Informs the server if the peer alias lookup per channel should be
+    // enabled. It is turned off by default in order to avoid degradation of
+    // performance for existing clients.
+    bool peer_alias_lookup = 6;
 }
 message ListChannelsResponse {
     // The list of active channels
@@ -1869,12 +1968,16 @@ message GetInfoResponse {
     /*
     Whether the current node is connected to testnet. This field is
     deprecated and the network field should be used instead
-    **/
+    */
     bool testnet = 10 [deprecated = true];
 
     reserved 11;
 
-    // A list of active chains the node is connected to
+    /*
+    A list of active chains the node is connected to. This will only
+    ever contain a single entry since LND will only ever have a single
+    chain backend during its lifetime.
+    */
     repeated Chain chains = 16;
 
     // The URIs of the current node.
@@ -1890,6 +1993,17 @@ message GetInfoResponse {
     Indicates whether the HTLC interceptor API is in always-on mode.
     */
     bool require_htlc_interceptor = 21;
+
+    // Indicates whether final htlc resolutions are stored on disk.
+    bool store_final_htlc_resolutions = 22;
+}
+
+message GetDebugInfoRequest {
+}
+
+message GetDebugInfoResponse {
+    map<string, string> config = 1;
+    repeated string log = 2;
 }
 
 message GetRecoveryInfoRequest {
@@ -1906,8 +2020,9 @@ message GetRecoveryInfoResponse {
 }
 
 message Chain {
-    // The blockchain the node is on (eg bitcoin, litecoin)
-    string chain = 1;
+    // Deprecated. The chain is now always assumed to be bitcoin.
+    // The blockchain the node is on (must be bitcoin)
+    string chain = 1 [deprecated = true];
 
     // The network the node is on (eg regtest, testnet, mainnet)
     string network = 2;
@@ -1924,10 +2039,38 @@ message ChannelOpenUpdate {
     ChannelPoint channel_point = 1;
 }
 
+message CloseOutput {
+    // The amount in satoshi of this close output. This amount is the final
+    // commitment balance of the channel and the actual amount paid out on chain
+    // might be smaller due to subtracted fees.
+    int64 amount_sat = 1;
+
+    // The pkScript of the close output.
+    bytes pk_script = 2;
+
+    // Whether this output is for the local or remote node.
+    bool is_local = 3;
+
+    // The TLV encoded custom channel data records for this output, which might
+    // be set for custom channels.
+    bytes custom_channel_data = 4;
+}
+
 message ChannelCloseUpdate {
     bytes closing_txid = 1;
 
     bool success = 2;
+
+    // The local channel close output. If the local channel balance was dust to
+    // begin with, this output will not be set.
+    CloseOutput local_close_output = 3;
+
+    // The remote channel close output. If the remote channel balance was dust
+    // to begin with, this output will not be set.
+    CloseOutput remote_close_output = 4;
+
+    // Any additional outputs that might be added for custom channel types.
+    repeated CloseOutput additional_outputs = 5;
 }
 
 message CloseChannelRequest {
@@ -1967,18 +2110,27 @@ message CloseChannelRequest {
     //
     // NOTE: This field is only respected if we're the initiator of the channel.
     uint64 max_fee_per_vbyte = 7;
+
+    // If true, then the rpc call will not block while it awaits a closing txid.
+    // Consequently this RPC call will not return a closing txid if this value
+    // is set.
+    bool no_wait = 8;
 }
 
 message CloseStatusUpdate {
     oneof update {
         PendingUpdate close_pending = 1;
         ChannelCloseUpdate chan_close = 3;
+        InstantUpdate close_instant = 4;
     }
 }
 
 message PendingUpdate {
     bytes txid = 1;
     uint32 output_index = 2;
+}
+
+message InstantUpdate {
 }
 
 message ReadyForPsbtFunding {
@@ -2025,6 +2177,9 @@ message BatchOpenChannelRequest {
 
     // An optional label for the batch transaction, limited to 500 characters.
     string label = 6;
+
+    // The strategy to use for selecting coins during batch opening channels.
+    CoinSelectionStrategy coin_selection_strategy = 7;
 }
 
 message BatchOpenChannel {
@@ -2075,6 +2230,76 @@ message BatchOpenChannel {
     the remote peer supports explicit channel negotiation.
     */
     CommitmentType commitment_type = 9;
+
+    /*
+    The maximum amount of coins in millisatoshi that can be pending within
+    the channel. It only applies to the remote party.
+    */
+    uint64 remote_max_value_in_flight_msat = 10;
+
+    /*
+    The maximum number of concurrent HTLCs we will allow the remote party to add
+    to the commitment transaction.
+    */
+    uint32 remote_max_htlcs = 11;
+
+    /*
+    Max local csv is the maximum csv delay we will allow for our own commitment
+    transaction.
+    */
+    uint32 max_local_csv = 12;
+
+    /*
+    If this is true, then a zero-conf channel open will be attempted.
+    */
+    bool zero_conf = 13;
+
+    /*
+    If this is true, then an option-scid-alias channel-type open will be
+    attempted.
+    */
+    bool scid_alias = 14;
+
+    /*
+    The base fee charged regardless of the number of milli-satoshis sent.
+    */
+    uint64 base_fee = 15;
+
+    /*
+    The fee rate in ppm (parts per million) that will be charged in
+    proportion of the value of each forwarded HTLC.
+    */
+    uint64 fee_rate = 16;
+
+    /*
+    If use_base_fee is true the open channel announcement will update the
+    channel base fee with the value specified in base_fee. In the case of
+    a base_fee of 0 use_base_fee is needed downstream to distinguish whether
+    to use the default base fee value specified in the config or 0.
+    */
+    bool use_base_fee = 17;
+
+    /*
+    If use_fee_rate is true the open channel announcement will update the
+    channel fee rate with the value specified in fee_rate. In the case of
+    a fee_rate of 0 use_fee_rate is needed downstream to distinguish whether
+    to use the default fee rate value specified in the config or 0.
+    */
+    bool use_fee_rate = 18;
+
+    /*
+    The number of satoshis we require the remote peer to reserve. This value,
+    if specified, must be above the dust limit and below 20% of the channel
+    capacity.
+    */
+    uint64 remote_chan_reserve_sat = 19;
+
+    /*
+    An optional note-to-self to go along with the channel containing some
+    useful information. This is only ever stored locally and in no way impacts
+    the channel's operation.
+    */
+    string memo = 20;
 }
 
 message BatchOpenChannelResponse {
@@ -2189,6 +2414,59 @@ message OpenChannelRequest {
     attempted.
     */
     bool scid_alias = 20;
+
+    /*
+    The base fee charged regardless of the number of milli-satoshis sent.
+    */
+    uint64 base_fee = 21;
+
+    /*
+    The fee rate in ppm (parts per million) that will be charged in
+    proportion of the value of each forwarded HTLC.
+    */
+    uint64 fee_rate = 22;
+
+    /*
+    If use_base_fee is true the open channel announcement will update the
+    channel base fee with the value specified in base_fee. In the case of
+    a base_fee of 0 use_base_fee is needed downstream to distinguish whether
+    to use the default base fee value specified in the config or 0.
+    */
+    bool use_base_fee = 23;
+
+    /*
+    If use_fee_rate is true the open channel announcement will update the
+    channel fee rate with the value specified in fee_rate. In the case of
+    a fee_rate of 0 use_fee_rate is needed downstream to distinguish whether
+    to use the default fee rate value specified in the config or 0.
+    */
+    bool use_fee_rate = 24;
+
+    /*
+    The number of satoshis we require the remote peer to reserve. This value,
+    if specified, must be above the dust limit and below 20% of the channel
+    capacity.
+    */
+    uint64 remote_chan_reserve_sat = 25;
+
+    /*
+    If set, then lnd will attempt to commit all the coins under control of the
+    internal wallet to open the channel, and the LocalFundingAmount field must
+    be zero and is ignored.
+    */
+    bool fund_max = 26;
+
+    /*
+    An optional note-to-self to go along with the channel containing some
+    useful information. This is only ever stored locally and in no way impacts
+    the channel's operation.
+    */
+    string memo = 27;
+
+    /*
+    A list of selected outpoints that are allocated for channel funding.
+    */
+    repeated OutPoint outpoints = 28;
 }
 message OpenStatusUpdate {
     oneof update {
@@ -2270,6 +2548,11 @@ message ChanPointShim {
     the value is less than 500,000, or as an absolute height otherwise.
     */
     uint32 thaw_height = 6;
+
+    /*
+    Indicates that the funding output is using a MuSig2 multi-sig output.
+    */
+    bool musig2 = 7;
 }
 
 message PsbtShim {
@@ -2420,6 +2703,9 @@ message PendingHTLC {
 }
 
 message PendingChannelsRequest {
+    // Indicates whether to include the raw transaction hex for
+    // waiting_close_channels.
+    bool include_raw_tx = 1;
 }
 message PendingChannelsResponse {
     message PendingChannel {
@@ -2455,6 +2741,18 @@ message PendingChannelsResponse {
 
         // Whether this channel is advertised to the network or not.
         bool private = 12;
+
+        /*
+        An optional note-to-self to go along with the channel containing some
+        useful information. This is only ever stored locally and in no way
+        impacts the channel's operation.
+        */
+        string memo = 13;
+
+        /*
+        Custom channel data that might be populated in custom channels.
+        */
+        bytes custom_channel_data = 34;
     }
 
     message PendingOpenChannel {
@@ -2482,6 +2780,17 @@ message PendingChannelsResponse {
 
         // Previously used for confirmation_height. Do not reuse.
         reserved 2;
+
+        // The number of blocks until the funding transaction is considered
+        // expired. If this value gets close to zero, there is a risk that the
+        // channel funding will be canceled by the channel responder. The
+        // channel should be fee bumped using CPFP (see walletrpc.BumpFee) to
+        // ensure that the channel confirms in time. Otherwise a force-close
+        // will be necessary if the channel confirms after the funding
+        // transaction expires. A negative value means the channel responder has
+        // very likely canceled the funding and the channel will never become
+        // fully operational.
+        int32 funding_expiry_blocks = 3;
     }
 
     message WaitingCloseChannel {
@@ -2499,6 +2808,10 @@ message PendingChannelsResponse {
 
         // The transaction id of the closing transaction
         string closing_txid = 4;
+
+        // The raw hex encoded bytes of the closing transaction. Included if
+        // include_raw_tx in the request is true.
+        string closing_tx_hex = 5;
     }
 
     message Commitments {
@@ -2563,9 +2876,17 @@ message PendingChannelsResponse {
 
         repeated PendingHTLC pending_htlcs = 8;
 
+        /*
+          There are three resolution states for the anchor:
+          limbo, lost and recovered. Derive the current state
+          from the limbo and recovered balances.
+        */
         enum AnchorState {
+            // The recovered_balance is zero and limbo_balance is non-zero.
             LIMBO = 0;
+            // The recovered_balance is non-zero.
             RECOVERED = 1;
+            // A state that is neither LIMBO nor RECOVERED.
             LOST = 2;
         }
 
@@ -2626,6 +2947,14 @@ message WalletAccountBalance {
 }
 
 message WalletBalanceRequest {
+    // The wallet account the balance is shown for.
+    // If this is not specified, the balance of the "default" account is shown.
+    string account = 1;
+
+    // The minimum number of confirmations each one of your outputs used for the
+    // funding transaction must satisfy. If this is not specified, the default
+    // value of 1 is used.
+    int32 min_confs = 2;
 }
 
 message WalletBalanceResponse {
@@ -2683,6 +3012,12 @@ message ChannelBalanceResponse {
 
     // Sum of channels pending remote balances.
     Amount pending_open_remote_balance = 8;
+
+    /*
+    Custom channel data that might be populated if there are custom channels
+    present.
+    */
+    bytes custom_channel_data = 9;
 }
 
 message QueryRoutesRequest {
@@ -2711,6 +3046,9 @@ message QueryRoutesRequest {
     not add any additional block padding on top of final_ctlv_delta. This
     padding of a few blocks needs to be added manually or otherwise failures may
     happen when a block comes in while the payment is in flight.
+
+    Note: must not be set if making a payment to a blinded path (delta is
+    set by the aggregate parameters provided by blinded_payment_paths)
     */
     int32 final_cltv_delta = 4;
 
@@ -2785,11 +3123,20 @@ message QueryRoutesRequest {
     repeated lnrpc.RouteHint route_hints = 16;
 
     /*
+    An optional blinded path(s) to reach the destination. Note that the
+    introduction node must be provided as the first hop in the route.
+    */
+    repeated BlindedPaymentPath blinded_payment_paths = 19;
+
+    /*
     Features assumed to be supported by the final node. All transitive feature
     dependencies must also be set properly. For a given feature bit pair, either
     optional or remote may be set, but not both. If this field is nil or empty,
     the router will try to load destination features from the graph as a
     fallback.
+
+    Note: must not be set if making a payment to a blinded route (features
+    are provided in blinded_payment_paths).
     */
     repeated lnrpc.FeatureBit dest_features = 17;
 
@@ -2895,6 +3242,32 @@ message Hop {
 
     // The payment metadata to send along with the payment to the payee.
     bytes metadata = 13;
+
+    /*
+    Blinding point is an optional blinding point included for introduction
+    nodes in blinded paths. This field is mandatory for hops that represents
+    the introduction point in a blinded path.
+    */
+    bytes blinding_point = 14;
+
+    /*
+    Encrypted data is a receiver-produced blob of data that provides hops
+    in a blinded route with forwarding data. As this data is encrypted by
+    the recipient, we will not be able to parse it - it is essentially an
+    arbitrary blob of data from our node's perspective. This field is
+    mandatory for all hops in a blinded path, including the introduction
+    node.
+    */
+    bytes encrypted_data = 15;
+
+    /*
+    The total amount that is sent to the recipient (possibly across multiple
+    HTLCs), as specified by the sender when making a payment to a blinded path.
+    This value is only set in the final hop payload of a blinded payment. This
+    value is analogous to the MPPRecord that is used for regular (non-blinded)
+    MPP payments.
+    */
+    uint64 total_amt_msat = 16;
 }
 
 message MPPRecord {
@@ -2902,7 +3275,8 @@ message MPPRecord {
     A unique, random identifier used to authenticate the sender as the intended
     payer of a multi-path payment. The payment_addr must be the same for all
     subpayments, and match the payment_addr provided in the receiver's invoice.
-    The same payment_addr must be used on all subpayments.
+    The same payment_addr must be used on all subpayments. This is also called
+    payment secret in specifications (e.g. BOLT 11).
     */
     bytes payment_addr = 11;
 
@@ -2969,6 +3343,20 @@ message Route {
     The total amount in millisatoshis.
     */
     int64 total_amt_msat = 6;
+
+    /*
+    The actual on-chain amount that was sent out to the first hop. This value is
+    only different from the total_amt_msat field if this is a custom channel
+    payment and the value transported in the HTLC is different from the BTC
+    amount in the HTLC. If this value is zero, then this is an old payment that
+    didn't have this value yet and can be ignored.
+    */
+    int64 first_hop_amount_msat = 7;
+
+    /*
+    Custom channel data that might be populated in custom channels.
+    */
+    bytes custom_channel_data = 8;
 }
 
 message NodeInfoRequest {
@@ -3011,6 +3399,9 @@ message LightningNode {
     repeated NodeAddress addresses = 4;
     string color = 5;
     map<uint32, Feature> features = 6;
+
+    // Custom node announcement tlv records.
+    map<uint64, bytes> custom_records = 7;
 }
 
 message NodeAddress {
@@ -3026,6 +3417,12 @@ message RoutingPolicy {
     bool disabled = 5;
     uint64 max_htlc_msat = 6;
     uint32 last_update = 7;
+
+    // Custom channel update tlv records.
+    map<uint64, bytes> custom_records = 8;
+
+    int32 inbound_fee_base_msat = 9;
+    int32 inbound_fee_rate_milli_msat = 10;
 }
 
 /*
@@ -3053,6 +3450,9 @@ message ChannelEdge {
 
     RoutingPolicy node1_policy = 7;
     RoutingPolicy node2_policy = 8;
+
+    // Custom channel announcement tlv records.
+    map<uint64, bytes> custom_records = 9;
 }
 
 message ChannelGraphRequest {
@@ -3109,6 +3509,10 @@ message ChanInfoRequest {
     output index for the channel.
     */
     uint64 chan_id = 1 [jstype = JS_STRING];
+
+    // The channel point of the channel in format funding_txid:output_index. If
+    // chan_id is specified, this field is ignored.
+    string chan_point = 2;
 }
 
 message NetworkInfoRequest {
@@ -3231,6 +3635,64 @@ message RouteHint {
     repeated HopHint hop_hints = 1;
 }
 
+message BlindedPaymentPath {
+    // The blinded path to send the payment to.
+    BlindedPath blinded_path = 1;
+
+    // The base fee for the blinded path provided, expressed in msat.
+    uint64 base_fee_msat = 2;
+
+    /*
+    The proportional fee for the blinded path provided, expressed in parts
+    per million.
+    */
+    uint32 proportional_fee_rate = 3;
+
+    /*
+    The total CLTV delta for the blinded path provided, including the
+    final CLTV delta for the receiving node.
+    */
+    uint32 total_cltv_delta = 4;
+
+    /*
+    The minimum hltc size that may be sent over the blinded path, expressed
+    in msat.
+    */
+    uint64 htlc_min_msat = 5;
+
+    /*
+    The maximum htlc size that may be sent over the blinded path, expressed
+    in msat.
+    */
+    uint64 htlc_max_msat = 6;
+
+    // The feature bits for the route.
+    repeated FeatureBit features = 7;
+}
+
+message BlindedPath {
+    // The unblinded pubkey of the introduction node for the route.
+    bytes introduction_node = 1;
+
+    // The ephemeral pubkey used by nodes in the blinded route.
+    bytes blinding_point = 2;
+
+    /*
+    A set of blinded node keys and data blobs for the blinded portion of the
+    route. Note that the first hop is expected to be the introduction node,
+    so the route is always expected to have at least one hop.
+    */
+    repeated BlindedHop blinded_hops = 3;
+}
+
+message BlindedHop {
+    // The blinded public key of the node.
+    bytes blinded_node = 1;
+
+    // An encrypted blob of data provided to the blinded node.
+    bytes encrypted_data = 2;
+}
+
 message AMPInvoiceState {
     // The state the HTLCs associated with this setID are in.
     InvoiceHTLCState state = 1;
@@ -3285,7 +3747,7 @@ message Invoice {
     int64 value_msat = 23;
 
     /*
-    Whether this invoice has been fulfilled
+    Whether this invoice has been fulfilled.
 
     The field is deprecated. Use the state field instead (compare to SETTLED).
     */
@@ -3293,12 +3755,14 @@ message Invoice {
 
     /*
     When this invoice was created.
+    Measured in seconds since the unix epoch.
     Note: Output only, don't specify for creating an invoice.
     */
     int64 creation_date = 7;
 
     /*
     When this invoice was settled.
+    Measured in seconds since the unix epoch.
     Note: Output only, don't specify for creating an invoice.
     */
     int64 settle_date = 8;
@@ -3319,7 +3783,7 @@ message Invoice {
     */
     bytes description_hash = 10;
 
-    // Payment request expiry time in seconds. Default is 3600 (1 hour).
+    // Payment request expiry time in seconds. Default is 86400 (24 hours).
     int64 expiry = 11;
 
     // Fallback on-chain address.
@@ -3335,6 +3799,8 @@ message Invoice {
     repeated RouteHint route_hints = 14;
 
     // Whether this invoice should include routing hints for private channels.
+    // Note: When enabled, if value and value_msat are zero, a large number of
+    // hints with these channels can be included, which might not be desirable.
     bool private = 15;
 
     /*
@@ -3360,22 +3826,22 @@ message Invoice {
 
     /*
     The amount that was accepted for this invoice, in satoshis. This will ONLY
-    be set if this invoice has been settled. We provide this field as if the
-    invoice was created with a zero value, then we need to record what amount
-    was ultimately accepted. Additionally, it's possible that the sender paid
-    MORE that was specified in the original invoice. So we'll record that here
-    as well.
+    be set if this invoice has been settled or accepted. We provide this field
+    as if the invoice was created with a zero value, then we need to record what
+    amount was ultimately accepted. Additionally, it's possible that the sender
+    paid MORE that was specified in the original invoice. So we'll record that
+    here as well.
     Note: Output only, don't specify for creating an invoice.
     */
     int64 amt_paid_sat = 19;
 
     /*
     The amount that was accepted for this invoice, in millisatoshis. This will
-    ONLY be set if this invoice has been settled. We provide this field as if
-    the invoice was created with a zero value, then we need to record what
-    amount was ultimately accepted. Additionally, it's possible that the sender
-    paid MORE that was specified in the original invoice. So we'll record that
-    here as well.
+    ONLY be set if this invoice has been settled or accepted. We provide this
+    field as if the invoice was created with a zero value, then we need to
+    record what amount was ultimately accepted. Additionally, it's possible that
+    the sender paid MORE that was specified in the original invoice. So we'll
+    record that here as well.
     Note: Output only, don't specify for creating an invoice.
     */
     int64 amt_paid_msat = 20;
@@ -3413,9 +3879,10 @@ message Invoice {
     bool is_keysend = 25;
 
     /*
-    The payment address of this invoice. This value will be used in MPP
-    payments, and also for newer invoices that always require the MPP payload
-    for added end-to-end security.
+    The payment address of this invoice. This is also called payment secret in
+    specifications (e.g. BOLT 11). This value will be used in MPP payments, and
+    also for newer invoices that always require the MPP payload for added
+    end-to-end security.
     Note: Output only, don't specify for creating an invoice.
     */
     bytes payment_addr = 26;
@@ -3435,6 +3902,48 @@ message Invoice {
     Note: Output only, don't specify for creating an invoice.
     */
     map<string, AMPInvoiceState> amp_invoice_state = 28;
+
+    /*
+    Signals that the invoice should include blinded paths to hide the true
+    identity of the recipient.
+    */
+    bool is_blinded = 29;
+
+    /*
+    Config values to use when creating blinded paths for this invoice. These
+    can be used to override the defaults config values provided in by the
+    global config. This field is only used if is_blinded is true.
+    */
+    BlindedPathConfig blinded_path_config = 30;
+}
+
+message BlindedPathConfig {
+    /*
+    The minimum number of real hops to include in a blinded path. This doesn't
+    include our node, so if the minimum is 1, then the path will contain at
+    minimum our node along with an introduction node hop. If it is zero then
+    the shortest path will use our node as an introduction node.
+    */
+    optional uint32 min_num_real_hops = 1;
+
+    /*
+    The number of hops to include in a blinded path. This doesn't include our
+    node, so if it is 1, then the path will contain our node along with an
+    introduction node or dummy node hop. If paths shorter than NumHops is
+    found, then they will be padded using dummy hops.
+    */
+    optional uint32 num_hops = 2;
+
+    /*
+    The maximum number of blinded paths to select and add to an invoice.
+    */
+    optional uint32 max_num_paths = 3;
+
+    /*
+    A list of node IDs of nodes that should not be used in any of our generated
+    blinded paths.
+    */
+    repeated bytes node_omission_list = 4;
 }
 
 enum InvoiceHTLCState {
@@ -3477,6 +3986,11 @@ message InvoiceHTLC {
 
     // Details relevant to AMP HTLCs, only populated if this is an AMP HTLC.
     AMP amp = 11;
+
+    /*
+    Custom channel data that might be populated in custom channels.
+    */
+    bytes custom_channel_data = 12;
 }
 
 // Details specific to AMP HTLCs.
@@ -3520,9 +4034,9 @@ message AddInvoiceResponse {
     uint64 add_index = 16;
 
     /*
-    The payment address of the generated invoice. This value should be used
-    in all payments for this invoice as we require it for end to end
-    security.
+    The payment address of the generated invoice. This is also called
+    payment secret in specifications (e.g. BOLT 11). This value should be used
+    in all payments for this invoice as we require it for end to end security.
     */
     bytes payment_addr = 17;
 }
@@ -3563,7 +4077,16 @@ message ListInvoiceRequest {
     specified index offset. This can be used to paginate backwards.
     */
     bool reversed = 6;
+
+    // If set, returns all invoices with a creation date greater than or equal
+    // to it. Measured in seconds since the unix epoch.
+    uint64 creation_date_start = 7;
+
+    // If set, returns all invoices with a creation date less than or equal to
+    // it. Measured in seconds since the unix epoch.
+    uint64 creation_date_end = 8;
 }
+
 message ListInvoiceResponse {
     /*
     A list of invoices from the time slice of the time series specified in the
@@ -3634,6 +4157,11 @@ enum PaymentFailureReason {
     Insufficient local balance.
     */
     FAILURE_REASON_INSUFFICIENT_BALANCE = 5;
+
+    /*
+    The payment was canceled.
+    */
+    FAILURE_REASON_CANCELED = 6;
 }
 
 message Payment {
@@ -3664,10 +4192,20 @@ message Payment {
     string payment_request = 9;
 
     enum PaymentStatus {
-        UNKNOWN = 0;
+        // Deprecated. This status will never be returned.
+        UNKNOWN = 0 [deprecated = true];
+
+        // Payment has inflight HTLCs.
         IN_FLIGHT = 1;
+
+        // Payment is settled.
         SUCCEEDED = 2;
+
+        // Payment is failed.
         FAILED = 3;
+
+        // Payment is created and has not attempted any HTLCs.
+        INITIATED = 4;
     }
 
     // The status of the payment.
@@ -3693,6 +4231,12 @@ message Payment {
     uint64 payment_index = 15;
 
     PaymentFailureReason failure_reason = 16;
+
+    /*
+    The custom TLV records that were sent to the first hop as part of the HTLC
+    wire message for this payment.
+    */
+    map<uint64, bytes> first_hop_custom_records = 17;
 }
 
 message HTLCAttempt {
@@ -3762,6 +4306,14 @@ message ListPaymentsRequest {
     of payments, as all of them have to be iterated through to be counted.
     */
     bool count_total_payments = 5;
+
+    // If set, returns all payments with a creation date greater than or equal
+    // to it. Measured in seconds since the unix epoch.
+    uint64 creation_date_start = 6;
+
+    // If set, returns all payments with a creation date less than or equal to
+    // it. Measured in seconds since the unix epoch.
+    uint64 creation_date_end = 7;
 }
 
 message ListPaymentsResponse {
@@ -3807,6 +4359,10 @@ message DeleteAllPaymentsRequest {
     Only delete failed HTLCs from payments, not the payment itself.
     */
     bool failed_htlcs_only = 2;
+
+    // Delete all payments. NOTE: Using this option requires careful
+    // consideration as it is a destructive operation.
+    bool all_payments = 3;
 }
 
 message DeletePaymentResponse {
@@ -3857,6 +4413,7 @@ message PayReq {
     bytes payment_addr = 11;
     int64 num_msat = 12;
     map<uint32, Feature> features = 13;
+    repeated BlindedPaymentPath blinded_paths = 14;
 }
 
 enum FeatureBit {
@@ -3883,6 +4440,8 @@ enum FeatureBit {
     ANCHORS_OPT = 21;
     ANCHORS_ZERO_FEE_HTLC_REQ = 22;
     ANCHORS_ZERO_FEE_HTLC_OPT = 23;
+    ROUTE_BLINDING_REQUIRED = 24;
+    ROUTE_BLINDING_OPTIONAL = 25;
     AMP_REQ = 30;
     AMP_OPT = 31;
 }
@@ -3912,7 +4471,15 @@ message ChannelFeeReport {
     // The effective fee rate in milli-satoshis. Computed by dividing the
     // fee_per_mil value by 1 million.
     double fee_rate = 4;
+
+    // The base fee charged regardless of the number of milli-satoshis sent.
+    int32 inbound_base_fee_msat = 6;
+
+    // The amount charged per milli-satoshis transferred expressed in
+    // millionths of a satoshi.
+    int32 inbound_fee_per_mil = 7;
 }
+
 message FeeReportResponse {
     // An array of channel fee reports which describes the current fee schedule
     // for each channel.
@@ -3929,6 +4496,16 @@ message FeeReportResponse {
     // The total amount of fee revenue (in satoshis) the switch has collected
     // over the past 1 month.
     uint64 month_fee_sum = 4;
+}
+
+message InboundFee {
+    // The inbound base fee charged regardless of the number of milli-satoshis
+    // received in the channel. By default, only negative values are accepted.
+    int32 base_fee_msat = 1;
+
+    // The effective inbound fee rate in micro-satoshis (parts per million).
+    // By default, only negative values are accepted.
+    int32 fee_rate_ppm = 2;
 }
 
 message PolicyUpdateRequest {
@@ -3963,7 +4540,21 @@ message PolicyUpdateRequest {
 
     // If true, min_htlc_msat is applied.
     bool min_htlc_msat_specified = 8;
+
+    // Optional inbound fee. If unset, the previously set value will be
+    // retained [EXPERIMENTAL].
+    InboundFee inbound_fee = 10;
+
+    // Under unknown circumstances a channel can exist with a missing edge in
+    // the graph database. This can cause an 'edge not found' error when calling
+    // `getchaninfo` and/or cause the default channel policy to be used during
+    // forwards. Setting this flag will recreate the edge if not found, allowing
+    // updating this channel policy and fixing the missing edge problem for this
+    // channel permanently. For fields not set in this command, the default
+    // policy will be created.
+    bool create_missing_edge = 11;
 }
+
 enum UpdateFailure {
     UPDATE_FAILURE_UNKNOWN = 0;
     UPDATE_FAILURE_PENDING = 1;
@@ -4006,6 +4597,10 @@ message ForwardingHistoryRequest {
 
     // The max number of events to return in the response to this query.
     uint32 num_max_events = 4;
+
+    // Informs the server if the peer alias should be looked up for each
+    // forwarding event.
+    bool peer_alias_lookup = 5;
 }
 message ForwardingEvent {
     // Timestamp is the time (unix epoch offset) that this circuit was
@@ -4044,6 +4639,12 @@ message ForwardingEvent {
     // The number of nanoseconds elapsed since January 1, 1970 UTC when this
     // circuit was completed.
     uint64 timestamp_ns = 11;
+
+    // The peer alias of the incoming channel.
+    string peer_alias_in = 12;
+
+    // The peer alias of the outgoing channel.
+    string peer_alias_out = 13;
 
     // TODO(roasbeef): add settlement latency?
     //  * use FPE on the chan id?
@@ -4229,6 +4830,7 @@ message Failure {
         EXPIRY_TOO_FAR = 22;
         MPP_TIMEOUT = 23;
         INVALID_ONION_PAYLOAD = 24;
+        INVALID_ONION_BLINDING = 25;
 
         /*
         An internal error occurred.

--- a/vendor/peersrpc/peers.proto
+++ b/vendor/peersrpc/peers.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-import "lightning.proto";
-
 package peersrpc;
+
+import "lightning.proto";
 
 option go_package = "github.com/lightningnetwork/lnd/lnrpc/peersrpc";
 

--- a/vendor/routerrpc/router.proto
+++ b/vendor/routerrpc/router.proto
@@ -1,10 +1,28 @@
 syntax = "proto3";
 
-import "lightning.proto";
-
 package routerrpc;
 
+import "lightning.proto";
+
 option go_package = "github.com/lightningnetwork/lnd/lnrpc/routerrpc";
+
+/*
+ * Comments in this file will be directly parsed into the API
+ * Documentation as descriptions of the associated method, message, or field.
+ * These descriptions should go right above the definition of the object, and
+ * can be in either block or // comment format.
+ *
+ * An RPC method can be matched to an lncli command by placing a line in the
+ * beginning of the description in exactly the following format:
+ * lncli: `methodname`
+ *
+ * Failure to specify the exact name of the command will cause documentation
+ * generation to fail.
+ *
+ * More information on how exactly the gRPC documentation is generated from
+ * this proto file can be found here:
+ * https://github.com/lightninglabs/lightning-api
+ */
 
 // Router is a service that offers advanced interaction with the router
 // subsystem of the daemon.
@@ -12,15 +30,28 @@ service Router {
     /*
     SendPaymentV2 attempts to route a payment described by the passed
     PaymentRequest to the final destination. The call returns a stream of
-    payment updates.
+    payment updates. When using this RPC, make sure to set a fee limit, as the
+    default routing fee limit is 0 sats. Without a non-zero fee limit only
+    routes without fees will be attempted which often fails with
+    FAILURE_REASON_NO_ROUTE.
     */
     rpc SendPaymentV2 (SendPaymentRequest) returns (stream lnrpc.Payment);
 
-    /*
+    /* lncli: `trackpayment`
     TrackPaymentV2 returns an update stream for the payment identified by the
     payment hash.
     */
     rpc TrackPaymentV2 (TrackPaymentRequest) returns (stream lnrpc.Payment);
+
+    /*
+    TrackPayments returns an update stream for every payment that is not in a
+    terminal state. Note that if payments are in-flight while starting a new
+    subscription, the start of the payment stream could produce out-of-order
+    and/or duplicate events. In order to get updates for every in-flight
+    payment attempt make sure to subscribe to this method before initiating any
+    payments.
+    */
+    rpc TrackPayments (TrackPaymentsRequest) returns (stream lnrpc.Payment);
 
     /*
     EstimateRouteFee allows callers to obtain a lower bound w.r.t how much it
@@ -47,21 +78,21 @@ service Router {
     */
     rpc SendToRouteV2 (SendToRouteRequest) returns (lnrpc.HTLCAttempt);
 
-    /*
+    /* lncli: `resetmc`
     ResetMissionControl clears all mission control state and starts with a clean
     slate.
     */
     rpc ResetMissionControl (ResetMissionControlRequest)
         returns (ResetMissionControlResponse);
 
-    /*
+    /* lncli: `querymc`
     QueryMissionControl exposes the internal mission control state to callers.
     It is a development feature.
     */
     rpc QueryMissionControl (QueryMissionControlRequest)
         returns (QueryMissionControlResponse);
 
-    /*
+    /* lncli: `importmc`
     XImportMissionControl is an experimental API that imports the state provided
     to the internal mission control's state, using all results which are more
     recent than our existing values. These values will only be imported
@@ -70,30 +101,36 @@ service Router {
     rpc XImportMissionControl (XImportMissionControlRequest)
         returns (XImportMissionControlResponse);
 
-    /*
+    /* lncli: `getmccfg`
     GetMissionControlConfig returns mission control's current config.
     */
     rpc GetMissionControlConfig (GetMissionControlConfigRequest)
         returns (GetMissionControlConfigResponse);
 
-    /*
+    /* lncli: `setmccfg`
     SetMissionControlConfig will set mission control's config, if the config
     provided is valid.
     */
     rpc SetMissionControlConfig (SetMissionControlConfigRequest)
         returns (SetMissionControlConfigResponse);
 
-    /*
-    QueryProbability returns the current success probability estimate for a
-    given node pair and amount.
+    /* lncli: `queryprob`
+    Deprecated. QueryProbability returns the current success probability
+    estimate for a given node pair and amount. The call returns a zero success
+    probability if no channel is available or if the amount violates min/max
+    HTLC constraints.
     */
     rpc QueryProbability (QueryProbabilityRequest)
         returns (QueryProbabilityResponse);
 
-    /*
+    /* lncli: `buildroute`
     BuildRoute builds a fully specified route based on a list of hop public
     keys. It retrieves the relevant channel policies from the graph in order to
     calculate the correct fees and time locks.
+    Note that LND will use its default final_cltv_delta if no value is supplied.
+    Make sure to add the correct final_cltv_delta depending on the invoice
+    restriction. Moreover the caller has to make sure to provide the
+    payment_addr if the route is paying an invoice which signaled it.
     */
     rpc BuildRoute (BuildRouteRequest) returns (BuildRouteResponse);
 
@@ -131,7 +168,7 @@ service Router {
     rpc HtlcInterceptor (stream ForwardHtlcInterceptResponse)
         returns (stream ForwardHtlcInterceptRequest);
 
-    /*
+    /* lncli: `updatechanstatus`
     UpdateChanStatus attempts to manually set the state of a channel
     (enabled, disabled, or auto). A manual "disable" request will cause the
     channel to stay disabled until a subsequent manual request of either
@@ -139,6 +176,25 @@ service Router {
     */
     rpc UpdateChanStatus (UpdateChanStatusRequest)
         returns (UpdateChanStatusResponse);
+
+    /*
+    XAddLocalChanAliases is an experimental API that creates a set of new
+    channel SCID alias mappings. The final total set of aliases in the manager
+    after the add operation is returned. This is only a locally stored alias,
+    and will not be communicated to the channel peer via any message. Therefore,
+    routing over such an alias will only work if the peer also calls this same
+    RPC on their end. If an alias already exists, an error is returned
+    */
+    rpc XAddLocalChanAliases (AddAliasesRequest) returns (AddAliasesResponse);
+
+    /*
+    XDeleteLocalChanAliases is an experimental API that deletes a set of alias
+    mappings. The final total set of aliases in the manager after the delete
+    operation is returned. The deletion will not be communicated to the channel
+    peer via any message.
+    */
+    rpc XDeleteLocalChanAliases (DeleteAliasesRequest)
+        returns (DeleteAliasesResponse);
 }
 
 message SendPaymentRequest {
@@ -152,13 +208,6 @@ message SendPaymentRequest {
     */
     int64 amt = 2;
 
-    /*
-    Number of millisatoshis to send.
-
-    The fields amt and amt_msat are mutually exclusive.
-    */
-    int64 amt_msat = 12;
-
     // The hash to use within the payment's HTLC
     bytes payment_hash = 3;
 
@@ -167,9 +216,6 @@ message SendPaymentRequest {
     timelock for the final hop.
     */
     int32 final_cltv_delta = 4;
-
-    // An optional payment addr to be included within the last hop of the route.
-    bytes payment_addr = 20;
 
     /*
     A bare-bones invoice for a payment within the Lightning Network.  With the
@@ -199,17 +245,6 @@ message SendPaymentRequest {
     int64 fee_limit_sat = 7;
 
     /*
-    The maximum number of millisatoshis that will be paid as a fee of the
-    payment. If this field is left to the default value of 0, only zero-fee
-    routes will be considered. This usually means single hop routes connecting
-    directly to the destination. To send the payment without a fee limit, use
-    max int here.
-
-    The fields fee_limit_sat and fee_limit_msat are mutually exclusive.
-    */
-    int64 fee_limit_msat = 13;
-
-    /*
     Deprecated, use outgoing_chan_ids. The channel id of the channel that must
     be taken to the first hop. If zero, any channel may be used (unless
     outgoing_chan_ids are set).
@@ -217,19 +252,8 @@ message SendPaymentRequest {
     uint64 outgoing_chan_id = 8 [jstype = JS_STRING, deprecated = true];
 
     /*
-    The channel ids of the channels are allowed for the first hop. If empty,
-    any channel may be used.
-    */
-    repeated uint64 outgoing_chan_ids = 19;
-
-    /*
-    The pubkey of the last hop of the route. If empty, any hop may be used.
-    */
-    bytes last_hop_pubkey = 14;
-
-    /*
-    An optional maximum total time lock for the route. This should not exceed
-    lnd's `--max-cltv-expiry` setting. If zero, then the value of
+    An optional maximum total time lock for the route. This should not
+    exceed lnd's `--max-cltv-expiry` setting. If zero, then the value of
     `--max-cltv-expiry` is enforced.
     */
     int32 cltv_limit = 9;
@@ -247,6 +271,29 @@ message SendPaymentRequest {
     must be encoded as base64.
     */
     map<uint64, bytes> dest_custom_records = 11;
+
+    /*
+    Number of millisatoshis to send.
+
+    The fields amt and amt_msat are mutually exclusive.
+    */
+    int64 amt_msat = 12;
+
+    /*
+    The maximum number of millisatoshis that will be paid as a fee of the
+    payment. If this field is left to the default value of 0, only zero-fee
+    routes will be considered. This usually means single hop routes connecting
+    directly to the destination. To send the payment without a fee limit, use
+    max int here.
+
+    The fields fee_limit_sat and fee_limit_msat are mutually exclusive.
+    */
+    int64 fee_limit_msat = 13;
+
+    /*
+    The pubkey of the last hop of the route. If empty, any hop may be used.
+    */
+    bytes last_hop_pubkey = 14;
 
     // If set, circular payments to self are permitted.
     bool allow_self_payment = 15;
@@ -273,6 +320,18 @@ message SendPaymentRequest {
     bool no_inflight_updates = 18;
 
     /*
+    The channel ids of the channels are allowed for the first hop. If empty,
+    any channel may be used.
+    */
+    repeated uint64 outgoing_chan_ids = 19;
+
+    /*
+    An optional payment addr to be included within the last hop of the route.
+    This is also called payment secret in specifications (e.g. BOLT 11).
+    */
+    bytes payment_addr = 20;
+
+    /*
     The largest payment split that should be attempted when making a payment if
     splitting is necessary. Setting this value will effectively cause lnd to
     split more aggressively, vs only when it thinks it needs to. Note that this
@@ -290,6 +349,24 @@ message SendPaymentRequest {
     only, to 1 to optimize for reliability only or a value inbetween for a mix.
     */
     double time_pref = 23;
+
+    /*
+    If set, the payment loop can be interrupted by manually canceling the
+    payment context, even before the payment timeout is reached. Note that the
+    payment may still succeed after cancellation, as in-flight attempts can
+    still settle afterwards. Canceling will only prevent further attempts from
+    being sent.
+    */
+    bool cancelable = 24;
+
+    /*
+    An optional field that can be used to pass an arbitrary set of TLV records
+    to the first hop peer of this payment. This can be used to pass application
+    specific data during the payment attempt. Record types are required to be in
+    the custom range >= 65536. When using REST, the values must be encoded as
+    base64.
+    */
+    map<uint64, bytes> first_hop_custom_records = 25;
 }
 
 message TrackPaymentRequest {
@@ -303,16 +380,49 @@ message TrackPaymentRequest {
     bool no_inflight_updates = 2;
 }
 
+message TrackPaymentsRequest {
+    /*
+    If set, only the final payment updates are streamed back. Intermediate
+    updates that show which htlcs are still in flight are suppressed.
+    */
+    bool no_inflight_updates = 1;
+}
+
 message RouteFeeRequest {
     /*
-    The destination once wishes to obtain a routing fee quote to.
+    The destination one wishes to obtain a routing fee quote to. If set, this
+    parameter requires the amt_sat parameter also to be set. This parameter
+    combination triggers a graph based routing fee estimation as opposed to a
+    payment probe based estimate in case a payment request is provided. The
+    graph based estimation is an algorithm that is executed on the in memory
+    graph. Hence its runtime is significantly shorter than a payment probe
+    estimation that sends out actual payments to the network.
     */
     bytes dest = 1;
 
     /*
-    The amount one wishes to send to the target destination.
+    The amount one wishes to send to the target destination. It is only to be
+    used in combination with the dest parameter.
     */
     int64 amt_sat = 2;
+
+    /*
+    A payment request of the target node that the route fee request is intended
+    for. Its parameters are input to probe payments that estimate routing fees.
+    The timeout parameter can be specified to set a maximum time on the probing
+    attempt. Cannot be used in combination with dest and amt_sat.
+    */
+    string payment_request = 3;
+
+    /*
+    A user preference of how long a probe payment should maximally be allowed to
+    take, denoted in seconds. The probing payment loop is aborted if this
+    timeout is reached. Note that the probing process itself can take longer
+    than the timeout if the HTLC becomes delayed or stuck. Canceling the context
+    of this call will not cancel the payment loop, the duration is only
+    controlled by the timeout parameter.
+    */
+    uint32 timeout = 4;
 }
 
 message RouteFeeResponse {
@@ -328,6 +438,12 @@ message RouteFeeResponse {
     value.
     */
     int64 time_lock_delay = 2;
+
+    /*
+    An indication whether a probing payment succeeded or whether and why it
+    failed. FAILURE_REASON_NONE indicates success.
+    */
+    lnrpc.PaymentFailureReason failure_reason = 5;
 }
 
 message SendToRouteRequest {
@@ -344,6 +460,15 @@ message SendToRouteRequest {
     routes, incorrect payment details, or insufficient funds.
     */
     bool skip_temp_err = 3;
+
+    /*
+    An optional field that can be used to pass an arbitrary set of TLV records
+    to the first hop peer of this payment. This can be used to pass application
+    specific data during the payment attempt. Record types are required to be in
+    the custom range >= 65536. When using REST, the values must be encoded as
+    base64.
+    */
+    map<uint64, bytes> first_hop_custom_records = 4;
 }
 
 message SendToRouteResponse {
@@ -448,6 +573,93 @@ message SetMissionControlConfigResponse {
 
 message MissionControlConfig {
     /*
+    Deprecated, use AprioriParameters. The amount of time mission control will
+    take to restore a penalized node or channel back to 50% success probability,
+    expressed in seconds. Setting this value to a higher value will penalize
+    failures for longer, making mission control less likely to route through
+    nodes and channels that we have previously recorded failures for.
+    */
+    uint64 half_life_seconds = 1 [deprecated = true];
+
+    /*
+    Deprecated, use AprioriParameters. The probability of success mission
+    control should assign to hop in a route where it has no other information
+    available. Higher values will make mission control more willing to try hops
+    that we have no information about, lower values will discourage trying these
+    hops.
+    */
+    float hop_probability = 2 [deprecated = true];
+
+    /*
+    Deprecated, use AprioriParameters. The importance that mission control
+    should place on historical results, expressed as a value in [0;1]. Setting
+    this value to 1 will ignore all historical payments and just use the hop
+    probability to assess the probability of success for each hop. A zero value
+    ignores hop probability completely and relies entirely on historical
+    results, unless none are available.
+    */
+    float weight = 3 [deprecated = true];
+
+    /*
+    The maximum number of payment results that mission control will store.
+    */
+    uint32 maximum_payment_results = 4;
+
+    /*
+    The minimum time that must have passed since the previously recorded failure
+    before we raise the failure amount.
+    */
+    uint64 minimum_failure_relax_interval = 5;
+
+    enum ProbabilityModel {
+        APRIORI = 0;
+        BIMODAL = 1;
+    }
+
+    /*
+    ProbabilityModel defines which probability estimator should be used in
+    pathfinding. Note that the bimodal estimator is experimental.
+    */
+    ProbabilityModel model = 6;
+
+    /*
+    EstimatorConfig is populated dependent on the estimator type.
+    */
+    oneof EstimatorConfig {
+        AprioriParameters apriori = 7;
+        BimodalParameters bimodal = 8;
+    }
+}
+
+message BimodalParameters {
+    /*
+    NodeWeight defines how strongly other previous forwardings on channels of a
+    router should be taken into account when computing a channel's probability
+    to route. The allowed values are in the range [0, 1], where a value of 0
+    means that only direct information about a channel is taken into account.
+    */
+    double node_weight = 1;
+
+    /*
+    ScaleMsat describes the scale over which channels statistically have some
+    liquidity left. The value determines how quickly the bimodal distribution
+    drops off from the edges of a channel. A larger value (compared to typical
+    channel capacities) means that the drop off is slow and that channel
+    balances are distributed more uniformly. A small value leads to the
+    assumption of very unbalanced channels.
+    */
+    uint64 scale_msat = 2;
+
+    /*
+    DecayTime describes the information decay of knowledge about previous
+    successes and failures in channels. The smaller the decay time, the quicker
+    we forget about past forwardings.
+    */
+    uint64 decay_time = 3;
+}
+
+message AprioriParameters {
+    /*
     The amount of time mission control will take to restore a penalized node
     or channel back to 50% success probability, expressed in seconds. Setting
     this value to a higher value will penalize failures for longer, making
@@ -462,7 +674,7 @@ message MissionControlConfig {
     control more willing to try hops that we have no information about, lower
     values will discourage trying these hops.
     */
-    float hop_probability = 2;
+    double hop_probability = 2;
 
     /*
     The importance that mission control should place on historical results,
@@ -472,18 +684,15 @@ message MissionControlConfig {
     completely and relies entirely on historical results, unless none are
     available.
     */
-    float weight = 3;
+    double weight = 3;
 
     /*
-    The maximum number of payment results that mission control will store.
+    The fraction of a channel's capacity that we consider to have liquidity. For
+    amounts that come close to or exceed the fraction, an additional penalty is
+    applied. A value of 1.0 disables the capacity factor. Allowed values are in
+    [0.75, 1.0].
     */
-    uint32 maximum_payment_results = 4;
-
-    /*
-    The minimum time that must have passed since the previously recorded failure
-    before we raise the failure amount.
-    */
-    uint64 minimum_failure_relax_interval = 5;
+    double capacity_fraction = 4;
 }
 
 message QueryProbabilityRequest {
@@ -530,8 +739,20 @@ message BuildRouteRequest {
     */
     repeated bytes hop_pubkeys = 4;
 
-    // An optional payment addr to be included within the last hop of the route.
+    /*
+    An optional payment addr to be included within the last hop of the route.
+    This is also called payment secret in specifications (e.g. BOLT 11).
+    */
     bytes payment_addr = 5;
+
+    /*
+    An optional field that can be used to pass an arbitrary set of TLV records
+    to the first hop peer of this payment. This can be used to pass application
+    specific data during the payment attempt. Record types are required to be in
+    the custom range >= 65536. When using REST, the values must be encoded as
+    base64.
+    */
+    map<uint64, bytes> first_hop_custom_records = 6;
 }
 
 message BuildRouteResponse {
@@ -600,6 +821,8 @@ message HtlcEvent {
         ForwardFailEvent forward_fail_event = 8;
         SettleEvent settle_event = 9;
         LinkFailEvent link_fail_event = 10;
+        SubscribedEvent subscribed_event = 11;
+        FinalHtlcEvent final_htlc_event = 12;
     }
 }
 
@@ -628,6 +851,14 @@ message ForwardFailEvent {
 message SettleEvent {
     // The revealed preimage.
     bytes preimage = 1;
+}
+
+message FinalHtlcEvent {
+    bool settled = 1;
+    bool offchain = 2;
+}
+
+message SubscribedEvent {
 }
 
 message LinkFailEvent {
@@ -774,12 +1005,21 @@ message ForwardHtlcInterceptRequest {
 
     // The onion blob for the next hop
     bytes onion_blob = 9;
+
+    // The block height at which this htlc will be auto-failed to prevent the
+    // channel from force-closing.
+    int32 auto_fail_height = 10;
+
+    // The custom records of the peer's incoming p2p wire message.
+    map<uint64, bytes> in_wire_custom_records = 11;
 }
 
 /**
 ForwardHtlcInterceptResponse enables the caller to resolve a previously hold
 forward. The caller can choose either to:
 - `Resume`: Execute the default behavior (usually forward).
+- `ResumeModified`: Execute the default behavior (usually forward) with HTLC
+                    field modifications.
 - `Reject`: Fail the htlc backwards.
 - `Settle`: Settle this htlc with a given preimage.
 */
@@ -810,12 +1050,36 @@ message ForwardHtlcInterceptResponse {
     // For backwards-compatibility reasons, TEMPORARY_CHANNEL_FAILURE is the
     // default value for this field.
     lnrpc.Failure.FailureCode failure_code = 5;
+
+    // The amount that was set on the p2p wire message of the incoming HTLC.
+    // This field is ignored if the action is not RESUME_MODIFIED or the amount
+    // is zero.
+    uint64 in_amount_msat = 6;
+
+    // The amount to set on the p2p wire message of the resumed HTLC. This field
+    // is ignored if the action is not RESUME_MODIFIED or the amount is zero.
+    uint64 out_amount_msat = 7;
+
+    // Any custom records that should be set on the p2p wire message message of
+    // the resumed HTLC. This field is ignored if the action is not
+    // RESUME_MODIFIED.
+    map<uint64, bytes> out_wire_custom_records = 8;
 }
 
 enum ResolveHoldForwardAction {
+    // SETTLE is an action that is used to settle an HTLC instead of forwarding
+    // it.
     SETTLE = 0;
+
+    // FAIL is an action that is used to fail an HTLC backwards.
     FAIL = 1;
+
+    // RESUME is an action that is used to resume a forward HTLC.
     RESUME = 2;
+
+    // RESUME_MODIFIED is an action that is used to resume a hold forward HTLC
+    // with modifications specified during interception.
+    RESUME_MODIFIED = 3;
 }
 
 message UpdateChanStatusRequest {
@@ -831,4 +1095,20 @@ enum ChanStatusAction {
 }
 
 message UpdateChanStatusResponse {
+}
+
+message AddAliasesRequest {
+    repeated lnrpc.AliasMap alias_maps = 1;
+}
+
+message AddAliasesResponse {
+    repeated lnrpc.AliasMap alias_maps = 1;
+}
+
+message DeleteAliasesRequest {
+    repeated lnrpc.AliasMap alias_maps = 1;
+}
+
+message DeleteAliasesResponse {
+    repeated lnrpc.AliasMap alias_maps = 1;
 }

--- a/vendor/signrpc/signer.proto
+++ b/vendor/signrpc/signer.proto
@@ -349,6 +349,12 @@ message SignMessageReq {
     privKey + h_tapTweak(internalKey || tapTweak)
     */
     bytes schnorr_sig_tap_tweak = 6;
+
+    /*
+    An optional tag that can be provided when taking a tagged hash of a
+    message. This option can only be used when schnorr_sig is true.
+    */
+    bytes tag = 7;
 }
 message SignMessageResp {
     /*
@@ -380,6 +386,12 @@ message VerifyMessageReq {
     Specifies if the signature is a Schnorr signature.
     */
     bool is_schnorr_sig = 4;
+
+    /*
+    An optional tag that can be provided when taking a tagged hash of a
+    message. This option can only be used when is_schnorr_sig is true.
+    */
+    bytes tag = 5;
 }
 
 message VerifyMessageResp {
@@ -444,17 +456,38 @@ message TaprootTweakDesc {
     bool key_spend_only = 2;
 }
 
+enum MuSig2Version {
+    /*
+    The default value on the RPC is zero for enums so we need to represent an
+    invalid/undefined version by default to make sure clients upgrade their
+    software to set the version explicitly.
+    */
+    MUSIG2_VERSION_UNDEFINED = 0;
+
+    /*
+    The version of MuSig2 that lnd 0.15.x shipped with, which corresponds to the
+    version v0.4.0 of the MuSig2 BIP draft.
+    */
+    MUSIG2_VERSION_V040 = 1;
+
+    /*
+    The current version of MuSig2 which corresponds to the version v1.0.0rc2 of
+    the MuSig2 BIP draft.
+    */
+    MUSIG2_VERSION_V100RC2 = 2;
+}
+
 message MuSig2CombineKeysRequest {
     /*
-    A list of all public keys (serialized in 32-byte x-only format!)
-    participating in the signing session. The list will always be sorted
-    lexicographically internally. This must include the local key which is
-    described by the above key_loc.
+    A list of all public keys (serialized in 32-byte x-only format for v0.4.0
+    and 33-byte compressed format for v1.0.0rc2!) participating in the signing
+    session. The list will always be sorted lexicographically internally. This
+    must include the local key which is described by the above key_loc.
     */
     repeated bytes all_signer_pubkeys = 1;
 
     /*
-    A series of optional generic tweaks to be applied to the the aggregated
+    A series of optional generic tweaks to be applied to the aggregated
     public key.
     */
     repeated TweakDesc tweaks = 2;
@@ -465,6 +498,14 @@ message MuSig2CombineKeysRequest {
     on-chain.
     */
     TaprootTweakDesc taproot_tweak = 3;
+
+    /*
+    The mandatory version of the MuSig2 BIP draft to use. This is necessary to
+    differentiate between the changes that were made to the BIP while this
+    experimental RPC was already released. Some of those changes affect how the
+    combined key and nonces are created.
+    */
+    MuSig2Version version = 4;
 }
 
 message MuSig2CombineKeysResponse {
@@ -482,6 +523,11 @@ message MuSig2CombineKeysResponse {
     is used.
     */
     bytes taproot_internal_key = 2;
+
+    /*
+    The version of the MuSig2 BIP that was used to combine the keys.
+    */
+    MuSig2Version version = 4;
 }
 
 message MuSig2SessionRequest {
@@ -491,10 +537,10 @@ message MuSig2SessionRequest {
     KeyLocator key_loc = 1;
 
     /*
-    A list of all public keys (serialized in 32-byte x-only format!)
-    participating in the signing session. The list will always be sorted
-    lexicographically internally. This must include the local key which is
-    described by the above key_loc.
+    A list of all public keys (serialized in 32-byte x-only format for v0.4.0
+    and 33-byte compressed format for v1.0.0rc2!) participating in the signing
+    session. The list will always be sorted lexicographically internally. This
+    must include the local key which is described by the above key_loc.
     */
     repeated bytes all_signer_pubkeys = 2;
 
@@ -505,7 +551,7 @@ message MuSig2SessionRequest {
     repeated bytes other_signer_public_nonces = 3;
 
     /*
-    A series of optional generic tweaks to be applied to the the aggregated
+    A series of optional generic tweaks to be applied to the aggregated
     public key.
     */
     repeated TweakDesc tweaks = 4;
@@ -516,6 +562,24 @@ message MuSig2SessionRequest {
     on-chain.
     */
     TaprootTweakDesc taproot_tweak = 5;
+
+    /*
+    The mandatory version of the MuSig2 BIP draft to use. This is necessary to
+    differentiate between the changes that were made to the BIP while this
+    experimental RPC was already released. Some of those changes affect how the
+    combined key and nonces are created.
+    */
+    MuSig2Version version = 6;
+
+    /*
+    A set of pre generated secret local nonces to use in the musig2 session.
+    This field is optional. This can be useful for protocols that need to send
+    nonces ahead of time before the set of signer keys are known. This value
+    MUST be 97 bytes and be the concatenation of two CSPRNG generated 32 byte
+    values and local public key used for signing as specified in the key_loc
+    field.
+    */
+    bytes pregenerated_local_nonce = 7;
 }
 
 message MuSig2SessionResponse {
@@ -553,6 +617,11 @@ message MuSig2SessionResponse {
     now.
     */
     bool have_all_nonces = 5;
+
+    /*
+    The version of the MuSig2 BIP that was used to create the session.
+    */
+    MuSig2Version version = 6;
 }
 
 message MuSig2RegisterNoncesRequest {

--- a/vendor/stateservice.proto
+++ b/vendor/stateservice.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 
-package staterpc;
+package lnrpc;
+
+option go_package = "github.com/lightningnetwork/lnd/lnrpc";
 
 /*
  * Comments in this file will be directly parsed into the API
@@ -34,14 +36,25 @@ service State {
 }
 
 enum WalletState {
+    // NON_EXISTING means that the wallet has not yet been initialized.
     NON_EXISTING = 0;
+
+    // LOCKED means that the wallet is locked and requires a password to unlock.
     LOCKED = 1;
+
+    // UNLOCKED means that the wallet was unlocked successfully, but RPC server
+    // isn't ready.
     UNLOCKED = 2;
+
+    // RPC_ACTIVE means that the lnd server is active but not fully ready for
+    // calls.
     RPC_ACTIVE = 3;
 
     // SERVER_ACTIVE means that the lnd server is ready to accept calls.
     SERVER_ACTIVE = 4;
 
+    // WAITING_TO_START means that node is waiting to become the leader in a
+    // cluster and is not started yet.
     WAITING_TO_START = 255;
 }
 

--- a/vendor/walletrpc/walletkit.proto
+++ b/vendor/walletrpc/walletkit.proto
@@ -1,11 +1,29 @@
 syntax = "proto3";
 
+package walletrpc;
+
 import "lightning.proto";
 import "signrpc/signer.proto";
 
-package walletrpc;
-
 option go_package = "github.com/lightningnetwork/lnd/lnrpc/walletrpc";
+
+/*
+ * Comments in this file will be directly parsed into the API
+ * Documentation as descriptions of the associated method, message, or field.
+ * These descriptions should go right above the definition of the object, and
+ * can be in either block or // comment format.
+ *
+ * An RPC method can be matched to an lncli command by placing a line in the
+ * beginning of the description in exactly the following format:
+ * lncli: `methodname`
+ *
+ * Failure to specify the exact name of the command will cause documentation
+ * generation to fail.
+ *
+ * More information on how exactly the gRPC documentation is generated from
+ * this proto file can be found here:
+ * https://github.com/lightninglabs/lightning-api
+ */
 
 // WalletKit is a service that gives access to the core functionalities of the
 // daemon's wallet.
@@ -18,7 +36,7 @@ service WalletKit {
     */
     rpc ListUnspent (ListUnspentRequest) returns (ListUnspentResponse);
 
-    /*
+    /* lncli: `wallet leaseoutput`
     LeaseOutput locks an output to the given ID, preventing it from being
     available for any future coin selection attempts. The absolute time of the
     lock's expiration is returned. The expiration of the lock can be extended by
@@ -27,14 +45,14 @@ service WalletKit {
     */
     rpc LeaseOutput (LeaseOutputRequest) returns (LeaseOutputResponse);
 
-    /*
+    /* lncli: `wallet releaseoutput`
     ReleaseOutput unlocks an output, allowing it to be available for coin
     selection if it remains unspent. The ID should match the one used to
     originally lock the output.
     */
     rpc ReleaseOutput (ReleaseOutputRequest) returns (ReleaseOutputResponse);
 
-    /*
+    /* lncli: `wallet listleases`
     ListLeases lists all currently locked utxos.
     */
     rpc ListLeases (ListLeasesRequest) returns (ListLeasesResponse);
@@ -57,14 +75,19 @@ service WalletKit {
     */
     rpc NextAddr (AddrRequest) returns (AddrResponse);
 
-    /*
+    /* lncli: `wallet gettx`
+    GetTransaction returns details for a transaction found in the wallet.
+    */
+    rpc GetTransaction (GetTransactionRequest) returns (lnrpc.Transaction);
+
+    /* lncli: `wallet accounts list`
     ListAccounts retrieves all accounts belonging to the wallet by default. A
     name and key scope filter can be provided to filter through all of the
     wallet accounts and return only those matching.
     */
     rpc ListAccounts (ListAccountsRequest) returns (ListAccountsResponse);
 
-    /*
+    /* lncli: `wallet requiredreserve`
     RequiredReserve returns the minimum amount of satoshis that should be kept
     in the wallet in order to fee bump anchor channels if necessary. The value
     scales with the number of public anchor channels but is capped at a maximum.
@@ -72,7 +95,55 @@ service WalletKit {
     rpc RequiredReserve (RequiredReserveRequest)
         returns (RequiredReserveResponse);
 
-    /*
+    /* lncli: `wallet addresses list`
+    ListAddresses retrieves all the addresses along with their balance. An
+    account name filter can be provided to filter through all of the
+    wallet accounts and return the addresses of only those matching.
+    */
+    rpc ListAddresses (ListAddressesRequest) returns (ListAddressesResponse);
+
+    /* lncli: `wallet addresses signmessage`
+    SignMessageWithAddr returns the compact signature (base64 encoded) created
+    with the private key of the provided address. This requires the address
+    to be solely based on a public key lock (no scripts). Obviously the internal
+    lnd wallet has to possess the private key of the address otherwise
+    an error is returned.
+
+    This method aims to provide full compatibility with the bitcoin-core and
+    btcd implementation. Bitcoin-core's algorithm is not specified in a
+    BIP and only applicable for legacy addresses. This method enhances the
+    signing for additional address types: P2WKH, NP2WKH, P2TR.
+    For P2TR addresses this represents a special case. ECDSA is used to create
+    a compact signature which makes the public key of the signature recoverable.
+    */
+    rpc SignMessageWithAddr (SignMessageWithAddrRequest)
+        returns (SignMessageWithAddrResponse);
+
+    /* lncli: `wallet addresses verifymessage`
+    VerifyMessageWithAddr returns the validity and the recovered public key of
+    the provided compact signature (base64 encoded). The verification is
+    twofold. First the validity of the signature itself is checked and then
+    it is verified that the recovered public key of the signature equals
+    the public key of the provided address. There is no dependence on the
+    private key of the address therefore also external addresses are allowed
+    to verify signatures.
+    Supported address types are P2PKH, P2WKH, NP2WKH, P2TR.
+
+    This method is the counterpart of the related signing method
+    (SignMessageWithAddr) and aims to provide full compatibility to
+    bitcoin-core's implementation. Although bitcoin-core/btcd only provide
+    this functionality for legacy addresses this function enhances it to
+    the address types: P2PKH, P2WKH, NP2WKH, P2TR.
+
+    The verification for P2TR addresses is a special case and requires the
+    ECDSA compact signature to compare the reovered public key to the internal
+    taproot key. The compact ECDSA signature format was used because there
+    are still no known compact signature schemes for schnorr signatures.
+    */
+    rpc VerifyMessageWithAddr (VerifyMessageWithAddrRequest)
+        returns (VerifyMessageWithAddrResponse);
+
+    /* lncli: `wallet accounts import`
     ImportAccount imports an account backed by an account extended public key.
     The master key fingerprint denotes the fingerprint of the root key
     corresponding to the account public key (also known as the key with
@@ -99,8 +170,12 @@ service WalletKit {
     */
     rpc ImportAccount (ImportAccountRequest) returns (ImportAccountResponse);
 
-    /*
-    ImportPublicKey imports a public key as watch-only into the wallet.
+    /* lncli: `wallet accounts import-pubkey`
+    ImportPublicKey imports a public key as watch-only into the wallet. The
+    public key is converted into a simple address of the given type and that
+    address script is watched on chain. For Taproot keys, this will only watch
+    the BIP-0086 style output script. Use ImportTapscript for more advanced key
+    spend or script spend outputs.
 
     NOTE: Events (deposits/spends) for a key will only be detected by lnd if
     they happen after the import. Rescans to detect past events will be
@@ -110,12 +185,35 @@ service WalletKit {
         returns (ImportPublicKeyResponse);
 
     /*
+    ImportTapscript imports a Taproot script and internal key and adds the
+    resulting Taproot output key as a watch-only output script into the wallet.
+    For BIP-0086 style Taproot keys (no root hash commitment and no script spend
+    path) use ImportPublicKey.
+
+    NOTE: Events (deposits/spends) for a key will only be detected by lnd if
+    they happen after the import. Rescans to detect past events will be
+    supported later on.
+
+    NOTE: Taproot keys imported through this RPC currently _cannot_ be used for
+    funding PSBTs. Only tracking the balance and UTXOs is currently supported.
+    */
+    rpc ImportTapscript (ImportTapscriptRequest)
+        returns (ImportTapscriptResponse);
+
+    /* lncli: `wallet publishtx`
     PublishTransaction attempts to publish the passed transaction to the
     network. Once this returns without an error, the wallet will continually
     attempt to re-broadcast the transaction on start up, until it enters the
     chain.
     */
     rpc PublishTransaction (Transaction) returns (PublishResponse);
+
+    /* lncli: `wallet removetx`
+    RemoveTransaction attempts to remove the provided transaction from the
+    internal transaction store of the wallet.
+    */
+    rpc RemoveTransaction (GetTransactionRequest)
+        returns (RemoveTransactionResponse);
 
     /*
     SendOutputs is similar to the existing sendmany call in Bitcoind, and
@@ -131,7 +229,7 @@ service WalletKit {
     */
     rpc EstimateFee (EstimateFeeRequest) returns (EstimateFeeResponse);
 
-    /*
+    /* lncli: `pendingsweeps`
     PendingSweeps returns lists of on-chain outputs that lnd is currently
     attempting to sweep within its central batching engine. Outputs with similar
     fee rates are batched together in order to sweep them within a single
@@ -143,62 +241,75 @@ service WalletKit {
     */
     rpc PendingSweeps (PendingSweepsRequest) returns (PendingSweepsResponse);
 
-    /*
-    BumpFee bumps the fee of an arbitrary input within a transaction. This RPC
-    takes a different approach than bitcoind's bumpfee command. lnd has a
-    central batching engine in which inputs with similar fee rates are batched
-    together to save on transaction fees. Due to this, we cannot rely on
-    bumping the fee on a specific transaction, since transactions can change at
-    any point with the addition of new inputs. The list of inputs that
-    currently exist within lnd's central batching engine can be retrieved
-    through the PendingSweeps RPC.
+    /* lncli: `wallet bumpfee`
+    BumpFee is an endpoint that allows users to interact with lnd's sweeper
+    directly. It takes an outpoint from an unconfirmed transaction and sends it
+    to the sweeper for potential fee bumping. Depending on whether the outpoint
+    has been registered in the sweeper (an existing input, e.g., an anchor
+    output) or not (a new input, e.g., an unconfirmed wallet utxo), this will
+    either be an RBF or CPFP attempt.
 
-    When bumping the fee of an input that currently exists within lnd's central
-    batching engine, a higher fee transaction will be created that replaces the
-    lower fee transaction through the Replace-By-Fee (RBF) policy. If it
+    When receiving an input, lnd’s sweeper needs to understand its time
+    sensitivity to make economical fee bumps - internally a fee function is
+    created using the deadline and budget to guide the process. When the
+    deadline is approaching, the fee function will increase the fee rate and
+    perform an RBF.
+
+    When a force close happens, all the outputs from the force closing
+    transaction will be registered in the sweeper. The sweeper will then handle
+    the creation, publish, and fee bumping of the sweeping transactions.
+    Everytime a new block comes in, unless the sweeping transaction is
+    confirmed, an RBF is attempted. To interfere with this automatic process,
+    users can use BumpFee to specify customized fee rate, budget, deadline, and
+    whether the sweep should happen immediately. It's recommended to call
+    `ListSweeps` to understand the shape of the existing sweeping transaction
+    first - depending on the number of inputs in this transaction, the RBF
+    requirements can be quite different.
 
     This RPC also serves useful when wanting to perform a Child-Pays-For-Parent
     (CPFP), where the child transaction pays for its parent's fee. This can be
     done by specifying an outpoint within the low fee transaction that is under
     the control of the wallet.
-
-    The fee preference can be expressed either as a specific fee rate or a delta
-    of blocks in which the output should be swept on-chain within. If a fee
-    preference is not explicitly specified, then an error is returned.
-
-    Note that this RPC currently doesn't perform any validation checks on the
-    fee preference being provided. For now, the responsibility of ensuring that
-    the new fee preference is sufficient is delegated to the user.
     */
     rpc BumpFee (BumpFeeRequest) returns (BumpFeeResponse);
 
-    /*
+    /* lncli: `wallet listsweeps`
     ListSweeps returns a list of the sweep transactions our node has produced.
     Note that these sweeps may not be confirmed yet, as we record sweeps on
     broadcast, not confirmation.
     */
     rpc ListSweeps (ListSweepsRequest) returns (ListSweepsResponse);
 
-    /*
+    /* lncli: `wallet labeltx`
     LabelTransaction adds a label to a transaction. If the transaction already
     has a label the call will fail unless the overwrite bool is set. This will
-    overwrite the exiting transaction label. Labels must not be empty, and
+    overwrite the existing transaction label. Labels must not be empty, and
     cannot exceed 500 characters.
     */
     rpc LabelTransaction (LabelTransactionRequest)
         returns (LabelTransactionResponse);
 
-    /*
+    /* lncli: `wallet psbt fund`
     FundPsbt creates a fully populated PSBT that contains enough inputs to fund
-    the outputs specified in the template. There are two ways of specifying a
-    template: Either by passing in a PSBT with at least one output declared or
-    by passing in a raw TxTemplate message.
+    the outputs specified in the template. There are three ways a user can
+    specify what we call the template (a list of inputs and outputs to use in
+    the PSBT): Either as a PSBT packet directly with no coin selection (using
+    the legacy "psbt" field), a PSBT with advanced coin selection support (using
+    the new "coin_select" field) or as a raw RPC message (using the "raw"
+    field).
+    The legacy "psbt" and "raw" modes, the following restrictions apply:
+          1. If there are no inputs specified in the template, coin selection is
+          performed automatically.
+          2. If the template does contain any inputs, it is assumed that full
+    coin selection happened externally and no additional inputs are added. If
+    the specified inputs aren't enough to fund the outputs with the given fee
+          rate, an error is returned.
 
-    If there are no inputs specified in the template, coin selection is
-    performed automatically. If the template does contain any inputs, it is
-    assumed that full coin selection happened externally and no additional
-    inputs are added. If the specified inputs aren't enough to fund the outputs
-    with the given fee rate, an error is returned.
+    The new "coin_select" mode does not have these restrictions and allows the
+    user to specify a PSBT with inputs and outputs and still perform coin
+    selection on top of that.
+    For all modes this RPC requires any inputs that are specified to be locked
+    by the user (if they belong to this node in the first place).
 
     After either selecting or verifying the inputs, all input UTXOs are locked
     with an internal app ID.
@@ -225,7 +336,7 @@ service WalletKit {
     */
     rpc SignPsbt (SignPsbtRequest) returns (SignPsbtResponse);
 
-    /*
+    /* lncli: `wallet psbt finalize`
     FinalizePsbt expects a partial transaction with all inputs and outputs fully
     declared and tries to sign all inputs that belong to the wallet. Lnd must be
     the last signer of the transaction. That means, if there are any unsigned
@@ -348,14 +459,7 @@ message Account {
     // The name used to identify the account.
     string name = 1;
 
-    /*
-    The type of addresses the account supports.
-    AddressType                       | External Branch | Internal Branch
-    ---------------------------------------------------------------------
-    WITNESS_PUBKEY_HASH               | P2WPKH          | P2WPKH
-    NESTED_WITNESS_PUBKEY_HASH        | NP2WPKH         | NP2WPKH
-    HYBRID_NESTED_WITNESS_PUBKEY_HASH | NP2WPKH         | P2WPKH
-    */
+    // The type of addresses the account supports.
     AddressType address_type = 2;
 
     /*
@@ -397,6 +501,57 @@ message Account {
     // Whether the wallet stores private keys for the account.
     bool watch_only = 8;
 }
+
+message AddressProperty {
+    /*
+    The address encoded using the appropriate format depending on the
+    address type (base58, bech32, bech32m).
+
+    Note that lnd's internal/custom keys for channels and other
+    functionality are derived from the same scope. Since they
+    aren't really used as addresses and will never have an
+    on-chain balance, we'll show the public key instead (only if
+    the show_custom_accounts flag is provided).
+    */
+    string address = 1;
+
+    // Denotes if the address is a change address.
+    bool is_internal = 2;
+
+    // The balance of the address.
+    int64 balance = 3;
+
+    // The full derivation path of the address. This will be empty for imported
+    // addresses.
+    string derivation_path = 4;
+
+    // The public key of the address. This will be empty for imported addresses.
+    bytes public_key = 5;
+}
+
+message AccountWithAddresses {
+    // The name used to identify the account.
+    string name = 1;
+
+    // The type of addresses the account supports.
+    AddressType address_type = 2;
+
+    /*
+    The derivation path corresponding to the account public key. This will
+    always be empty for the default imported account in which single public keys
+    are imported into.
+    */
+    string derivation_path = 3;
+
+    /*
+    List of address, its type internal/external & balance.
+    Note that the order of addresses will be random and not according to the
+    derivation index, since that information is not stored by the underlying
+    wallet.
+    */
+    repeated AddressProperty addresses = 4;
+}
+
 message ListAccountsRequest {
     // An optional filter to only return accounts matching this name.
     string name = 1;
@@ -404,6 +559,7 @@ message ListAccountsRequest {
     // An optional filter to only return accounts matching this address type.
     AddressType address_type = 2;
 }
+
 message ListAccountsResponse {
     repeated Account accounts = 1;
 }
@@ -416,6 +572,62 @@ message RequiredReserveRequest {
 message RequiredReserveResponse {
     // The amount of reserve required.
     int64 required_reserve = 1;
+}
+
+message ListAddressesRequest {
+    // An optional filter to only return addresses matching this account.
+    string account_name = 1;
+
+    // An optional flag to return LND's custom accounts (Purpose=1017)
+    // public key along with other addresses.
+    bool show_custom_accounts = 2;
+}
+
+message ListAddressesResponse {
+    // A list of all the accounts and their addresses.
+    repeated AccountWithAddresses account_with_addresses = 1;
+}
+
+message GetTransactionRequest {
+    // The txid of the transaction.
+    string txid = 1;
+}
+
+message SignMessageWithAddrRequest {
+    // The message to be signed. When using REST, this field must be encoded as
+    // base64.
+    bytes msg = 1;
+
+    // The address which will be used to look up the private key and sign the
+    // corresponding message.
+    string addr = 2;
+}
+
+message SignMessageWithAddrResponse {
+    // The compact ECDSA signature for the given message encoded in base64.
+    string signature = 1;
+}
+
+message VerifyMessageWithAddrRequest {
+    // The message to be signed. When using REST, this field must be encoded as
+    // base64.
+    bytes msg = 1;
+
+    // The compact ECDSA signature to be verified over the given message
+    // ecoded in base64.
+    string signature = 2;
+
+    // The address which will be used to look up the public key and verify the
+    // the signature.
+    string addr = 3;
+}
+
+message VerifyMessageWithAddrResponse {
+    // Whether the signature was valid over the given message.
+    bool valid = 1;
+
+    // The pubkey recovered from the signature.
+    bytes pubkey = 2;
 }
 
 message ImportAccountRequest {
@@ -482,9 +694,82 @@ message ImportPublicKeyRequest {
 message ImportPublicKeyResponse {
 }
 
+message ImportTapscriptRequest {
+    /*
+    The internal public key, serialized as 32-byte x-only public key.
+    */
+    bytes internal_public_key = 1;
+
+    oneof script {
+        /*
+        The full script tree with all individual leaves is known and the root
+        hash can be constructed from the full tree directly.
+        */
+        TapscriptFullTree full_tree = 2;
+
+        /*
+        Only a single script leaf is known. To construct the root hash, the full
+        inclusion proof must also be provided.
+        */
+        TapscriptPartialReveal partial_reveal = 3;
+
+        /*
+        Only the root hash of the Taproot script tree (or other form of Taproot
+        commitment) is known.
+        */
+        bytes root_hash_only = 4;
+
+        /*
+        Only the final, tweaked Taproot key is known and no additional
+        information about the internal key or type of tweak that was used to
+        derive it. When this is set, the wallet treats the key in
+        internal_public_key as the Taproot key directly. This can be useful for
+        tracking arbitrary Taproot outputs without the goal of ever being able
+        to spend from them through the internal wallet.
+        */
+        bool full_key_only = 5;
+    }
+}
+
+message TapscriptFullTree {
+    /*
+    The complete, ordered list of all tap leaves of the tree.
+    */
+    repeated TapLeaf all_leaves = 1;
+}
+
+message TapLeaf {
+    // The leaf version. Should be 0xc0 (192) in case of a SegWit v1 script.
+    uint32 leaf_version = 1;
+
+    // The script of the tap leaf.
+    bytes script = 2;
+}
+
+message TapscriptPartialReveal {
+    // The tap leaf that is known and will be revealed.
+    TapLeaf revealed_leaf = 1;
+
+    // The BIP-0341 serialized inclusion proof that is required to prove that
+    // the revealed leaf is part of the tree. This contains 0..n blocks of 32
+    // bytes. If the tree only contained a single leaf (which is the revealed
+    // leaf), this can be empty.
+    bytes full_inclusion_proof = 2;
+}
+
+message ImportTapscriptResponse {
+    /*
+    The resulting pay-to-Taproot address that represents the imported internal
+    key with the script committed to it.
+    */
+    string p2tr_address = 1;
+}
+
 message Transaction {
     /*
-    The raw serialized transaction.
+    The raw serialized transaction. Despite the field name, this does need to be
+    specified in raw bytes (or base64 encoded when using REST) and not in hex.
+    To not break existing software, the field can't simply be renamed.
     */
     bytes tx_hex = 1;
 
@@ -493,6 +778,7 @@ message Transaction {
     */
     string label = 2;
 }
+
 message PublishResponse {
     /*
     If blank, then no error occurred and the transaction was successfully
@@ -502,6 +788,11 @@ message PublishResponse {
     TODO(roasbeef): map to a proper enum type
     */
     string publish_error = 1;
+}
+
+message RemoveTransactionResponse {
+    // The status of the remove transaction operation.
+    string status = 1;
 }
 
 message SendOutputsRequest {
@@ -525,6 +816,9 @@ message SendOutputsRequest {
 
     // Whether unconfirmed outputs should be used as inputs for the transaction.
     bool spend_unconfirmed = 5;
+
+    // The strategy to use for selecting coins during sending the outputs.
+    lnrpc.CoinSelectionStrategy coin_selection_strategy = 6;
 }
 message SendOutputsResponse {
     /*
@@ -545,6 +839,9 @@ message EstimateFeeResponse {
     confirmation target in the request.
     */
     int64 sat_per_kw = 1;
+
+    // The current minimum relay fee based on our chain backend in sat/kw.
+    int64 min_relay_fee_sat_per_kw = 2;
 }
 
 enum WitnessType {
@@ -635,6 +932,161 @@ enum WitnessType {
     transaction.
     */
     COMMITMENT_ANCHOR = 13;
+
+    /*
+    A witness type that is similar to the COMMITMENT_NO_DELAY type,
+    but it omits the tweak that randomizes the key we need to
+    spend with a channel peer supplied set of randomness.
+    */
+    COMMITMENT_NO_DELAY_TWEAKLESS = 14;
+
+    /*
+    A witness type that allows us to spend our output on the counterparty's
+    commitment transaction after a confirmation.
+    */
+    COMMITMENT_TO_REMOTE_CONFIRMED = 15;
+
+    /*
+    A witness type that allows us to sweep an HTLC output that we extended
+    to a party, but was never fulfilled. This _is_ the HTLC output directly
+    on our commitment transaction, and the input to the second-level HTLC
+    timeout transaction. It can only be spent after CLTV expiry, and
+    commitment confirmation.
+    */
+    HTLC_OFFERED_TIMEOUT_SECOND_LEVEL_INPUT_CONFIRMED = 16;
+
+    /*
+    A witness type that allows us to sweep an HTLC output that was offered
+    to us, and for which we have a payment preimage. This _is_ the HTLC
+    output directly on our commitment transaction, and the input to the
+    second-level HTLC success transaction. It can only be spent after the
+    commitment has confirmed.
+    */
+    HTLC_ACCEPTED_SUCCESS_SECOND_LEVEL_INPUT_CONFIRMED = 17;
+
+    /*
+    A witness type that allows us to spend our output on our local
+    commitment transaction after a relative and absolute lock-time lockout as
+    part of the script enforced lease commitment type.
+    */
+    LEASE_COMMITMENT_TIME_LOCK = 18;
+
+    /*
+    A witness type that allows us to spend our output on the counterparty's
+    commitment transaction after a confirmation and absolute locktime as part
+    of the script enforced lease commitment type.
+    */
+    LEASE_COMMITMENT_TO_REMOTE_CONFIRMED = 19;
+
+    /*
+    A witness type that allows us to sweep an HTLC output that we extended
+    to a party, but was never fulfilled. This HTLC output isn't directly on
+    the commitment transaction, but is the result of a confirmed second-level
+    HTLC transaction. As a result, we can only spend this after a CSV delay
+    and CLTV locktime as part of the script enforced lease commitment type.
+    */
+    LEASE_HTLC_OFFERED_TIMEOUT_SECOND_LEVEL = 20;
+
+    /*
+    A witness type that allows us to sweep an HTLC output that was offered
+    to us, and for which we have a payment preimage. This HTLC output isn't
+    directly on our commitment transaction, but is the result of confirmed
+    second-level HTLC transaction. As a result, we can only spend this after
+    a CSV delay and CLTV locktime as part of the script enforced lease
+    commitment type.
+    */
+    LEASE_HTLC_ACCEPTED_SUCCESS_SECOND_LEVEL = 21;
+
+    /*
+    A witness type that allows us to spend a regular p2tr output that's sent
+    to an output which is under complete control of the backing wallet.
+    */
+    TAPROOT_PUB_KEY_SPEND = 22;
+
+    /*
+    A witness type that allows us to spend our settled local commitment after a
+    CSV delay when we force close the channel.
+    */
+    TAPROOT_LOCAL_COMMIT_SPEND = 23;
+
+    /*
+    A witness type that allows us to spend our settled local commitment after
+    a CSV delay when the remote party has force closed the channel.
+    */
+    TAPROOT_REMOTE_COMMIT_SPEND = 24;
+
+    /*
+    A witness type that we'll use for spending our own anchor output.
+    */
+    TAPROOT_ANCHOR_SWEEP_SPEND = 25;
+
+    /*
+    A witness that allows us to timeout an HTLC we offered to the remote party
+    on our commitment transaction. We use this when we need to go on chain to
+    time out an HTLC.
+    */
+    TAPROOT_HTLC_OFFERED_TIMEOUT_SECOND_LEVEL = 26;
+
+    /*
+    A witness type that allows us to sweep an HTLC we accepted on our commitment
+    transaction after we go to the second level on chain.
+    */
+    TAPROOT_HTLC_ACCEPTED_SUCCESS_SECOND_LEVEL = 27;
+
+    /*
+    A witness that allows us to sweep an HTLC on the revoked transaction of the
+    remote party that goes to the second level.
+    */
+    TAPROOT_HTLC_SECOND_LEVEL_REVOKE = 28;
+
+    /*
+    A witness that allows us to sweep an HTLC sent to us by the remote party
+    in the event that they broadcast a revoked state.
+    */
+    TAPROOT_HTLC_ACCEPTED_REVOKE = 29;
+
+    /*
+    A witness that allows us to sweep an HTLC we offered to the remote party if
+    they broadcast a revoked commitment.
+    */
+    TAPROOT_HTLC_OFFERED_REVOKE = 30;
+
+    /*
+    A witness that allows us to sweep an HTLC we offered to the remote party
+    that lies on the commitment transaction for the remote party. We can spend
+    this output after the absolute CLTV timeout of the HTLC as passed.
+    */
+    TAPROOT_HTLC_OFFERED_REMOTE_TIMEOUT = 31;
+
+    /*
+    A witness type that allows us to sign the second level HTLC timeout
+    transaction when spending from an HTLC residing on our local commitment
+    transaction.
+    This is used by the sweeper to re-sign inputs if it needs to aggregate
+    several second level HTLCs.
+    */
+    TAPROOT_HTLC_LOCAL_OFFERED_TIMEOUT = 32;
+
+    /*
+    A witness that allows us to sweep an HTLC that was offered to us by the
+    remote party for a taproot channels. We use this witness in the case that
+    the remote party goes to chain, and we know the pre-image to the HTLC. We
+    can sweep this without any additional timeout.
+    */
+    TAPROOT_HTLC_ACCEPTED_REMOTE_SUCCESS = 33;
+
+    /*
+    A witness type that allows us to sweep the HTLC offered to us on our local
+    commitment transaction. We'll use this when we need to go on chain to sweep
+    the HTLC. In this case, this is the second level HTLC success transaction.
+    */
+    TAPROOT_HTLC_ACCEPTED_LOCAL_SUCCESS = 34;
+
+    /*
+    A witness that allows us to sweep the settled output of a malicious
+    counterparty's who broadcasts a revoked taproot commitment transaction.
+    */
+    TAPROOT_COMMITMENT_REVOKE = 35;
 }
 
 message PendingSweep {
@@ -659,33 +1111,56 @@ message PendingSweep {
     uint32 broadcast_attempts = 5;
 
     /*
+    Deprecated.
     The next height of the chain at which we'll attempt to broadcast the
     sweep transaction of the output.
     */
-    uint32 next_broadcast_height = 6;
+    uint32 next_broadcast_height = 6 [deprecated = true];
 
-    // The requested confirmation target for this output.
-    uint32 requested_conf_target = 8;
+    /*
+    Deprecated, use immediate.
+    Whether this input must be force-swept. This means that it is swept
+    immediately.
+    */
+    bool force = 7 [deprecated = true];
+
+    /*
+    Deprecated, use deadline.
+    The requested confirmation target for this output, which is the deadline
+    used by the sweeper.
+    */
+    uint32 requested_conf_target = 8 [deprecated = true];
 
     // Deprecated, use requested_sat_per_vbyte.
     // The requested fee rate, expressed in sat/vbyte, for this output.
     uint32 requested_sat_per_byte = 9 [deprecated = true];
 
     /*
-    The fee rate we'll use to sweep the output, expressed in sat/vbyte. The fee
-    rate is only determined once a sweeping transaction for the output is
-    created, so it's possible for this to be 0 before this.
+    The current fee rate we'll use to sweep the output, expressed in sat/vbyte.
+    The fee rate is only determined once a sweeping transaction for the output
+    is created, so it's possible for this to be 0 before this.
     */
     uint64 sat_per_vbyte = 10;
 
-    // The requested fee rate, expressed in sat/vbyte, for this output.
+    // The requested starting fee rate, expressed in sat/vbyte, for this
+    // output. When not requested, this field will be 0.
     uint64 requested_sat_per_vbyte = 11;
 
     /*
-    Whether this input must be force-swept. This means that it is swept even
-    if it has a negative yield.
+    Whether this input will be swept immediately.
     */
-    bool force = 7;
+    bool immediate = 12;
+
+    /*
+    The budget for this sweep, expressed in satoshis. This is the maximum amount
+    that can be spent as fees to sweep this output.
+    */
+    uint64 budget = 13;
+
+    /*
+    The deadline height used for this output when perform fee bumping.
+    */
+    uint32 deadline_height = 14;
 }
 
 message PendingSweepsRequest {
@@ -702,7 +1177,8 @@ message BumpFeeRequest {
     // The input we're attempting to bump the fee of.
     lnrpc.OutPoint outpoint = 1;
 
-    // The target number of blocks that the input should be spent within.
+    // Optional. The conf target the underlying fee estimator will use to
+    // estimate the starting fee rate for the fee function.
     uint32 target_conf = 2;
 
     /*
@@ -713,19 +1189,46 @@ message BumpFeeRequest {
     uint32 sat_per_byte = 3 [deprecated = true];
 
     /*
-    Whether this input must be force-swept. This means that it is swept even
-    if it has a negative yield.
+    Deprecated, use immediate.
+    Whether this input must be force-swept. This means that it is swept
+    immediately.
     */
-    bool force = 4;
+    bool force = 4 [deprecated = true];
 
     /*
-    The fee rate, expressed in sat/vbyte, that should be used to spend the input
-    with.
+    Optional. The starting fee rate, expressed in sat/vbyte, that will be used
+    to spend the input with initially. This value will be used by the sweeper's
+    fee function as its starting fee rate. When not set, the sweeper will use
+    the estimated fee rate using the `target_conf` as the starting fee rate.
     */
     uint64 sat_per_vbyte = 5;
+
+    /*
+    Optional. Whether this input will be swept immediately. When set to true,
+    the sweeper will sweep this input without waiting for the next batch.
+    */
+    bool immediate = 6;
+
+    /*
+    Optional. The max amount in sats that can be used as the fees. Setting this
+    value greater than the input's value may result in CPFP - one or more wallet
+    utxos will be used to pay the fees specified by the budget. If not set, for
+    new inputs, by default 50% of the input's value will be treated as the
+    budget for fee bumping; for existing inputs, their current budgets will be
+    retained.
+    */
+    uint64 budget = 7;
+
+    // Optional. The deadline delta in number of blocks that the output
+    // should be spent within. This translates internally to the width of the
+    // fee function that the sweeper will use to bump the fee rate. When the
+    // deadline is reached, ALL the budget will be spent as fees.
+    uint32 deadline_delta = 8;
 }
 
 message BumpFeeResponse {
+    // The status of the bump fee operation.
+    string status = 1;
 }
 
 message ListSweepsRequest {
@@ -735,6 +1238,13 @@ message ListSweepsRequest {
     replaced-by-fee, so will not be included in this output.
     */
     bool verbose = 1;
+
+    /*
+    The start height to use when fetching sweeps. If not specified (0), the
+    result will start from the earliest sweep. If set to -1 the result will
+    only include unconfirmed sweeps (at the time of the call).
+    */
+    int32 start_height = 2;
 }
 
 message ListSweepsResponse {
@@ -754,7 +1264,8 @@ message ListSweepsResponse {
 }
 
 message LabelTransactionRequest {
-    // The txid of the transaction to label.
+    // The txid of the transaction to label. Note: When using gRPC, the bytes
+    // must be in little-endian (reverse) order.
     bytes txid = 1;
 
     // The label to add to the transaction, limited to 500 characters.
@@ -765,6 +1276,23 @@ message LabelTransactionRequest {
 }
 
 message LabelTransactionResponse {
+}
+
+// The possible change address types for default accounts and single imported
+// public keys. By default, P2WPKH will be used. We don't provide the
+// possibility to choose P2PKH as it is a legacy key scope, nor NP2WPKH as
+// no key scope permits to do so. For custom accounts, no change type should
+// be provided as the coin selection key scope will always be used to generate
+// the change address.
+enum ChangeAddressType {
+    // CHANGE_ADDRESS_TYPE_UNSPECIFIED indicates that no change address type is
+    // provided. We will then use P2WPKH address type for change (BIP0084 key
+    // scope).
+    CHANGE_ADDRESS_TYPE_UNSPECIFIED = 0;
+
+    // CHANGE_ADDRESS_TYPE_P2TR indicates to use P2TR address for change output
+    // (BIP0086 key scope).
+    CHANGE_ADDRESS_TYPE_P2TR = 1;
 }
 
 message FundPsbtRequest {
@@ -785,6 +1313,26 @@ message FundPsbtRequest {
         Use the outputs and optional inputs from this raw template.
         */
         TxTemplate raw = 2;
+
+        /*
+        Use an existing PSBT packet as the template for the funded PSBT.
+
+        The difference to the pure PSBT template above is that coin selection is
+        performed even if inputs are specified. The output amounts are summed up
+        and used as the target amount for coin selection. A change output must
+        either already exist in the PSBT and be marked as such, otherwise a new
+        change output of the specified output type will be added. Any inputs
+        already specified in the PSBT must already be locked (if they belong to
+        this node), only newly added inputs will be locked by this RPC.
+
+        In case the sum of the already provided inputs exceeds the required
+        output amount, no new coins are selected. Instead only the fee and
+        change amount calculation is performed (e.g. a change output is added if
+        requested or the change is added to the specified existing change
+        output, given there is any non-dust change). This can be identified by
+        the returned locked UTXOs being empty.
+        */
+        PsbtCoinSelect coin_select = 9;
     }
 
     oneof fees {
@@ -812,6 +1360,15 @@ message FundPsbtRequest {
 
     // Whether unconfirmed outputs should be used as inputs for the transaction.
     bool spend_unconfirmed = 7;
+
+    // The address type for the change. If empty, P2WPKH addresses will be used
+    // for default accounts and single imported public keys. For custom
+    // accounts, no change type should be provided as the coin selection key
+    // scope will always be used to generate the change address.
+    ChangeAddressType change_type = 8;
+
+    // The strategy to use for selecting coins during funding the PSBT.
+    lnrpc.CoinSelectionStrategy coin_selection_strategy = 10;
 }
 message FundPsbtResponse {
     /*
@@ -826,7 +1383,8 @@ message FundPsbtResponse {
 
     /*
     The list of lock leases that were acquired for the inputs in the funded PSBT
-    packet.
+    packet. Only inputs added to the PSBT by this RPC are locked, inputs that
+    were already present in the PSBT are not locked.
     */
     repeated UtxoLease locked_utxos = 3;
 }
@@ -847,6 +1405,38 @@ message TxTemplate {
     A map of all addresses and the amounts to send to in the funded PSBT.
     */
     map<string, uint64> outputs = 2;
+}
+
+message PsbtCoinSelect {
+    /*
+    The template to use for the funded PSBT. The template must contain at least
+    one non-dust output. The amount to be funded is calculated by summing up the
+    amounts of all outputs in the template, subtracting all the input values of
+    the already specified inputs. The change value is added to the output that
+    is marked as such (or a new change output is added if none is marked). For
+    the input amount calculation to be correct, the template must have the
+    WitnessUtxo field set for all inputs. Any inputs already specified in the
+    PSBT must already be locked (if they belong to this node), only newly added
+    inputs will be locked by this RPC.
+    */
+    bytes psbt = 1;
+
+    oneof change_output {
+        /*
+        Use the existing output within the template PSBT with the specified
+        index as the change output. Any leftover change will be added to the
+        already specified amount of that output. To add a new change output to
+        the PSBT, set the "add" field below instead. The type of change output
+        added is defined by change_type in the parent message.
+        */
+        int32 existing_output_index = 2;
+
+        /*
+        Add a new change output to the PSBT using the change_type specified in
+        the parent message.
+        */
+        bool add = 3;
+    }
 }
 
 message UtxoLease {
@@ -885,6 +1475,9 @@ message SignPsbtRequest {
 message SignPsbtResponse {
     // The signed transaction in PSBT format.
     bytes signed_psbt = 1;
+
+    // The indices of signed inputs.
+    repeated uint32 signed_inputs = 2;
 }
 
 message FinalizePsbtRequest {


### PR DESCRIPTION
updates the proto files to the latest release of lnd (18.5)

https://github.com/lightningnetwork/lnd/releases/tag/v0.18.5-beta

One very interesting change is lnd moved where the staterpc proto file is located, here we handle that change.